### PR TITLE
Add API for exceptional error conditions

### DIFF
--- a/core/rpc/mu-rpc.cabal
+++ b/core/rpc/mu-rpc.cabal
@@ -23,9 +23,8 @@ library
                        Mu.Rpc.Examples
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.12 && <5, sop-core,
-                       mu-schema, conduit, text,
-                       template-haskell
+  build-depends:       base >=4.12 && <5, mtl, sop-core,
+                       mu-schema, conduit, text, template-haskell
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -fprint-potential-instances

--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -55,14 +55,16 @@ newtype HiRequest = HiRequest { number :: Int }
 quickstartServer :: ServerIO QuickStartService _
 quickstartServer
   = Server (sayHello :<|>: sayHi :<|>: sayManyHellos :<|>: H0)
-  where sayHello :: HelloRequest -> IO HelloResponse
+  where sayHello :: HelloRequest -> ServerErrorIO HelloResponse
         sayHello (HelloRequest nm)
           = return (HelloResponse ("hi, " <> nm))
-        sayHi :: HiRequest -> ConduitT HelloResponse Void IO () -> IO ()
+        sayHi :: HiRequest
+              -> ConduitT HelloResponse Void ServerErrorIO ()
+              -> ServerErrorIO ()
         sayHi (HiRequest n) sink
           = runConduit $ C.replicate n (HelloResponse "hi!") .| sink
-        sayManyHellos :: ConduitT () HelloRequest IO ()
-                      -> ConduitT HelloResponse Void IO ()
-                      -> IO ()
+        sayManyHellos :: ConduitT () HelloRequest ServerErrorIO ()
+                      -> ConduitT HelloResponse Void ServerErrorIO ()
+                      -> ServerErrorIO ()
         sayManyHellos source sink
           = runConduit $ source .| C.mapM sayHello .| sink

--- a/core/rpc/src/Mu/Server.hs
+++ b/core/rpc/src/Mu/Server.hs
@@ -29,24 +29,50 @@ module Mu.Server (
   -- * Servers and handlers
   ServerIO, ServerT(..)
 , HandlersIO, HandlersT(..)
+  -- * Errors which might be raised
+, serverError, ServerErrorIO, ServerError(..), ServerErrorCode(..)
+  -- ** Useful when you do not want to deal with errors
+, alwaysOk
 ) where
 
+import           Control.Monad.Except
 import           Data.Conduit
 import           Data.Kind
 
 import           Mu.Rpc
 import           Mu.Schema
 
+serverError :: ServerError -> ServerErrorIO a
+serverError = throwError
+
+alwaysOk :: IO a -> ServerErrorIO a
+alwaysOk = liftIO
+
+data ServerError
+  = ServerError ServerErrorCode String
+
+data ServerErrorCode
+  = Unknown
+  | Unavailable
+  | Unimplemented
+  | Unauthenticated
+  | Internal
+  | Invalid
+  | NotFound
+  deriving (Eq, Show)
+
+type ServerErrorIO = ExceptT ServerError IO
+
 data ServerT (s :: Service snm mnm) (m :: Type -> Type) (hs :: [Type]) where
   Server :: HandlersT methods m hs -> ServerT ('Service sname anns methods) m hs
-type ServerIO service = ServerT service IO
+type ServerIO service = ServerT service ServerErrorIO
 
 infixr 5 :<|>:
 data HandlersT (methods :: [Method mnm]) (m :: Type -> Type) (hs :: [Type]) where
   H0 :: HandlersT '[] m '[]
   (:<|>:) :: Handles args ret m h => h -> HandlersT ms m hs
           -> HandlersT ('Method name anns args ret ': ms) m (h ': hs)
-type HandlersIO methods = HandlersT methods IO
+type HandlersIO methods = HandlersT methods ServerErrorIO
 
 -- Define a relation for handling
 class Handles (args :: [Argument]) (ret :: Return)
@@ -60,13 +86,14 @@ instance HandlesRef ('FromRegistry subject t last) t
 -- Arguments
 instance (HandlesRef ref t, Handles args ret m h, handler ~ (t -> h))
          => Handles ('ArgSingle ref ': args) ret m handler
-instance (HandlesRef ref t, Handles args ret m h, handler ~ (ConduitT () t IO () -> h))
+instance (HandlesRef ref t, Handles args ret m h, handler ~ (ConduitT () t m () -> h))
          => Handles ('ArgStream ref ': args) ret m handler
 -- Result with exception
-instance handler ~ m () => Handles '[] 'RetNothing m handler
-instance (HandlesRef eref e, HandlesRef vref v, handler ~ m (Either e v))
+instance (MonadError ServerError m, handler ~ m ())
+         => Handles '[] 'RetNothing m handler
+instance (MonadError ServerError m, HandlesRef eref e, HandlesRef vref v, handler ~ m (Either e v))
          => Handles '[] ('RetThrows eref vref) m handler
-instance (HandlesRef ref v, handler ~ m v)
+instance (MonadError ServerError m, HandlesRef ref v, handler ~ m v)
          => Handles '[] ('RetSingle ref) m handler
-instance (HandlesRef ref v, handler ~ (ConduitT v Void m () -> m ()))
+instance (MonadError ServerError m, HandlesRef ref v, handler ~ (ConduitT v Void m () -> m ()))
          => Handles '[] ('RetStream ref) m handler

--- a/core/rpc/src/Mu/Server.hs
+++ b/core/rpc/src/Mu/Server.hs
@@ -84,9 +84,11 @@ instance HasSchema sch sty t => HandlesRef ('FromSchema sch sty) t
 instance HandlesRef ('FromRegistry subject t last) t
 
 -- Arguments
-instance (HandlesRef ref t, Handles args ret m h, handler ~ (t -> h))
+instance (HandlesRef ref t, Handles args ret m h,
+          handler ~ (t -> h))
          => Handles ('ArgSingle ref ': args) ret m handler
-instance (HandlesRef ref t, Handles args ret m h, handler ~ (ConduitT () t m () -> h))
+instance (MonadError ServerError m, HandlesRef ref t, Handles args ret m h,
+          handler ~ (ConduitT () t m () -> h))
          => Handles ('ArgStream ref ': args) ret m handler
 -- Result with exception
 instance (MonadError ServerError m, handler ~ m ())

--- a/examples/route-guide/mu-example-route-guide.cabal
+++ b/examples/route-guide/mu-example-route-guide.cabal
@@ -32,7 +32,8 @@ executable route-guide-server
                        mu-schema, mu-rpc, mu-protobuf,
                        mu-grpc-server,
                        stm, stm-chans, hashable,
-                       conduit, AC-Angle, time, async
+                       conduit, AC-Angle, time, async,
+                       transformers
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/examples/route-guide/src/Server.hs
+++ b/examples/route-guide/src/Server.hs
@@ -7,10 +7,11 @@ module Main where
 import           Control.Concurrent.Async
 import           Control.Concurrent.STM
 import           Control.Concurrent.STM.TBMChan
-import           Control.Monad.IO.Class         (liftIO)
+import           Control.Monad.IO.Class         (MonadIO, liftIO)
 import           Data.Angle
 import           Data.Conduit
 import qualified Data.Conduit.Combinators       as C
+import           Data.Conduit.Lift              (runExceptC)
 import           Data.Conduit.List              (sourceList)
 import           Data.Function                  ((&))
 import           Data.Int
@@ -66,47 +67,57 @@ server :: Features -> TBMChan RouteNote -> ServerIO RouteGuideService _
 server f m = Server
   (getFeature f :<|>: listFeatures f  :<|>: recordRoute f :<|>: routeChat m :<|>: H0)
 
-getFeature :: Features -> Point -> IO Feature
+getFeature :: Features -> Point -> ServerErrorIO Feature
 getFeature fs p = return $ fromMaybe (Feature "" (Point 0 0)) (findFeatureIn fs p)
 
-listFeatures :: Features -> Rectangle -> ConduitT Feature Void IO () -> IO ()
+listFeatures :: Features -> Rectangle
+             -> ConduitT Feature Void ServerErrorIO ()
+             -> ServerErrorIO ()
 listFeatures fs rect result = runConduit $ sourceList (featuresWithinBounds fs rect) .| result
 
-recordRoute :: Features -> ConduitT () Point IO () -> IO RouteSummary
+recordRoute :: Features
+            -> ConduitT () Point ServerErrorIO ()
+            -> ServerErrorIO RouteSummary
 recordRoute fs ps = do
-    initialTime <- getCurrentTime
-    (rs, _, _) <- runConduit $ ps .| C.foldM step (RouteSummary 0 0 0 0, Nothing, initialTime)
-    return rs
+    initialTime <- liftIO getCurrentTime
+    (\(rs, _, _) -> rs) <$> runConduit (ps .| C.foldM step (RouteSummary 0 0 0 0, Nothing, initialTime))
   where
-    step :: (RouteSummary, Maybe Point, UTCTime) -> Point -> IO (RouteSummary, Maybe Point, UTCTime)
+    step :: (RouteSummary, Maybe Point, UTCTime) -> Point
+         -> ServerErrorIO (RouteSummary, Maybe Point, UTCTime)
     step (summary, previous, startTime) point = do
-      currentTime <- getCurrentTime
+      currentTime <- liftIO getCurrentTime
       let feature = findFeatureIn fs point
           new_distance = fmap (`calcDistance` point) previous & fromMaybe 0
           new_elapsed = diffUTCTime currentTime startTime
           new_summary = RouteSummary (point_count summary + 1)
-                                    (feature_count summary + if isJust feature then 1 else 0)
-                                    (distance summary + new_distance)
-                                    (floor new_elapsed)
+                                     (feature_count summary + if isJust feature then 1 else 0)
+                                     (distance summary + new_distance)
+                                     (floor new_elapsed)
       return (new_summary, Just point, startTime)
 
 routeChat :: TBMChan RouteNote
-          -> ConduitT () RouteNote IO () -> ConduitT RouteNote Void IO () -> IO ()
+          -> ConduitT () RouteNote ServerErrorIO ()
+          -> ConduitT RouteNote Void ServerErrorIO ()
+          -> ServerErrorIO ()
 routeChat notesMap inS outS = do
-    toWatch <- newEmptyTMVarIO
+    toWatch <- liftIO newEmptyTMVarIO
     -- Start two threads, one to listen, one to send
-    inA  <- async $ runConduit $ inS .| C.mapM_ (addNoteToMap toWatch)
-    outA <- async $ runConduit $ readStmMap (\l1 (RouteNote _ l2)-> l1 == l2) toWatch notesMap .| outS
-    wait inA
-    wait outA
+    let inA  = runConduit $ runExceptC $ inS .| C.mapM_ (addNoteToMap toWatch)
+        outA = runConduit $ runExceptC $
+                 readStmMap (\l1 (RouteNote _ l2)-> l1 == l2) toWatch notesMap .| outS
+    res <- liftIO $ concurrently inA outA
+    case res of
+      (Right _, Right _) -> return ()
+      (Left e, _)        -> serverError e
+      (_, Left e)        -> serverError e
   where
-    addNoteToMap :: TMVar Point -> RouteNote -> IO ()
-    addNoteToMap toWatch newNote@(RouteNote _ loc) = atomically $ do
+    addNoteToMap :: TMVar Point -> RouteNote -> ServerErrorIO ()
+    addNoteToMap toWatch newNote@(RouteNote _ loc) = liftIO $ atomically $ do
       _ <- tryTakeTMVar toWatch
       putTMVar toWatch loc
       writeTBMChan notesMap newNote
 
-readStmMap :: Show b => (a -> b -> Bool) -> TMVar a -> TBMChan b -> ConduitT () b IO ()
+readStmMap :: (MonadIO m, Show b) => (a -> b -> Bool) -> TMVar a -> TBMChan b -> ConduitT () b m ()
 readStmMap p toWatch m = go
   where
     go = do

--- a/examples/todolist/mu-example-todolist.cabal
+++ b/examples/todolist/mu-example-todolist.cabal
@@ -38,6 +38,7 @@ executable todolist-server
                      , mu-grpc-server
                      , stm
                      , text
+                     , transformers
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/grpc/server/mu-grpc-server.cabal
+++ b/grpc/server/mu-grpc-server.cabal
@@ -21,7 +21,7 @@ library
   exposed-modules:     Mu.GRpc.Server
   -- other-extensions:
   build-depends:       base >=4.12 && <5, sop-core,
-                       bytestring, async,
+                       bytestring, async, mtl,
                        mu-schema, mu-rpc, mu-protobuf,
                        warp, warp-grpc, wai, warp-tls,
                        http2-grpc-types, http2-grpc-proto3-wire,
@@ -34,7 +34,7 @@ executable grpc-example-server
   main-is:             ExampleServer.hs
   other-modules:       Mu.GRpc.Server
   build-depends:       base >=4.12 && <5, sop-core,
-                       bytestring, async,
+                       bytestring, async, mtl,
                        mu-schema, mu-rpc, mu-protobuf,
                        warp, warp-grpc, wai, warp-tls,
                        http2-grpc-types, http2-grpc-proto3-wire,


### PR DESCRIPTION
Following a meeting with @kutyel and @pepegar, we have drafted an API for exceptional conditions in `mu-haskell` (errors like *not found* or *not implemented*).

* We follow the design of both Servant and Mu, that is, and make the servers return `ExceptT ServerError IO a` instead of plain `IO a` as before.
* To make simple server unaware of the extra `ExceptT` layer, there's an `alwaysOk` function which lifts a simple handler in `IO` to work on `ExceptT ServerError IO`.

This PR implements that API and updates the examples to use it.

Comments are welcome. The main paint points are: 
* Conduits also have to be upgraded to use those monad transformers (do they? maybe we can make them unaware of external errors, but this does not seam real...)
* You have to sprinkle the `alwaysOk` here and there.