### PR TITLE
Separate annotations from core schema type

### DIFF
--- a/adapter/avro/src/Mu/Quasi/Avro.hs
+++ b/adapter/avro/src/Mu/Quasi/Avro.hs
@@ -49,23 +49,19 @@ schemaFromAvroString s =
 
 schemaDecFromAvroType :: A.Type -> Q Type
 schemaDecFromAvroType (A.Record name _ _ _ fields) =
-  [t|'DRecord $(textToStrLit $ A.baseName name) '[] $(typesToList <$>
-                                                      mapM
-                                                        avroFieldToType
-                                                        fields)|]
+  [t|'DRecord $(textToStrLit $ A.baseName name)
+              $(typesToList <$> mapM avroFieldToType fields)|]
   where
     avroFieldToType :: A.Field -> Q Type
     avroFieldToType field =
-      [t|'FieldDef $(textToStrLit $ A.fldName field) '[] $(schemaFromAvroType $
-                                                           A.fldType field)|]
+      [t|'FieldDef $(textToStrLit $ A.fldName field)
+                   $(schemaFromAvroType $ A.fldType field)|]
 schemaDecFromAvroType (A.Enum name _ _ symbols) =
-  [t|'DEnum $(textToStrLit $ A.baseName name) '[] $(typesToList <$>
-                                                    mapM
-                                                      avChoiceToType
-                                                      (toList symbols))|]
+  [t|'DEnum $(textToStrLit $ A.baseName name)
+            $(typesToList <$> mapM avChoiceToType (toList symbols))|]
   where
     avChoiceToType :: T.Text -> Q Type
-    avChoiceToType c = [t|'ChoiceDef $(textToStrLit c) '[]|]
+    avChoiceToType c = [t|'ChoiceDef $(textToStrLit c)|]
 schemaDecFromAvroType t = [t|'DSimple $(schemaFromAvroType t)|]
 
 schemaFromAvroType :: A.Type -> Q Type

--- a/adapter/protobuf/src/Mu/Adapter/ProtoBuf.hs
+++ b/adapter/protobuf/src/Mu/Adapter/ProtoBuf.hs
@@ -15,8 +15,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Mu.Adapter.ProtoBuf (
   -- * Custom annotations
-  ProtoBufId
-, ProtoBufOneOfIds
+  ProtoBufAnnotation(..)
   -- * Conversion using schemas
 , IsProtoSchema
 , HasProtoSchema
@@ -32,7 +31,6 @@ module Mu.Adapter.ProtoBuf (
 import           Control.Applicative
 import qualified Data.ByteString          as BS
 import           Data.Int
-import           Data.Kind
 import           Data.SOP                 (All)
 import qualified Data.Text                as T
 import qualified Data.Text.Lazy           as LT
@@ -47,17 +45,29 @@ import           Mu.Schema.Definition
 import           Mu.Schema.Interpretation
 import qualified Mu.Schema.Registry       as R
 
-type family FindProtoBufId (f :: fn) (xs :: [Type]) :: Nat where
-  FindProtoBufId f '[]
-    = TypeError ('Text "protocol buffers id not available for field " ':<>: 'ShowType f)
-  FindProtoBufId f (ProtoBufId n ': rest) = n
-  FindProtoBufId f (other        ': rest) = FindProtoBufId f rest
+data ProtoBufAnnotation
+  = ProtoBufId Nat
+  | ProtoBufOneOfIds [Nat]
 
-type family FindProtoBufOneOfIds (f :: fn) (xs :: [Type]) :: [Nat] where
-  FindProtoBufOneOfIds f '[]
-    = TypeError ('Text "protocol buffers ids not available for oneof field " ':<>: 'ShowType f)
-  FindProtoBufOneOfIds f (ProtoBufOneOfIds n ': rest) = n
-  FindProtoBufOneOfIds f (other              ': rest) = FindProtoBufOneOfIds f rest
+type family FindProtoBufId (sch :: Schema tn fn) (t :: tn) (f :: fn) where
+  FindProtoBufId sch t f
+    = FindProtoBufId' t f (GetFieldAnnotation (AnnotatedSchema ProtoBufAnnotation sch) t f)
+
+type family FindProtoBufId' (t :: tn) (f :: fn) (p :: ProtoBufAnnotation) :: Nat where
+  FindProtoBufId' t f ('ProtoBufId n) = n
+  FindProtoBufId' t f other
+    = TypeError ('Text "protocol buffers id not available for field "
+                 ':<>: 'ShowType t ':<>: 'Text "/" ':<>: 'ShowType f)
+
+type family FindProtoBufOneOfIds (sch :: Schema tn fn) (t :: tn) (f :: fn) where
+  FindProtoBufOneOfIds sch t f
+    = FindProtoBufOneOfIds' t f (GetFieldAnnotation (AnnotatedSchema ProtoBufAnnotation sch) t f)
+
+type family FindProtoBufOneOfIds' (t :: tn) (f :: fn) (p :: ProtoBufAnnotation) :: [Nat] where
+  FindProtoBufOneOfIds' t f ('ProtoBufOneOfIds ns) = ns
+  FindProtoBufOneOfIds' t f other
+    = TypeError ('Text "protocol buffers id not available for oneof field "
+                 ':<>: 'ShowType t ':<>: 'Text "/" ':<>: 'ShowType f)
 
 -- CONVERSION USING SCHEMAS
 
@@ -127,7 +137,7 @@ class ProtoBridgeEmbedTerm (sch :: Schema tn fn) (t :: TypeDef tn fn) where
   embedProtoToFieldValue :: PBDec.Parser PBDec.RawField (Term sch t)
   embedProtoToOneFieldValue :: PBDec.Parser PBDec.RawPrimitive (Term sch t)
 
-class ProtoBridgeField (sch :: Schema tn fn) (f :: FieldDef tn fn) where
+class ProtoBridgeField (sch :: Schema tn fn) (ty :: tn) (f :: FieldDef tn fn) where
   fieldToProto :: Field sch f -> PBEnc.MessageBuilder
   protoToField :: PBDec.Parser PBDec.RawMessage (Field sch f)
 
@@ -149,64 +159,64 @@ class ProtoBridgeUnionFieldValue (ids :: [Nat]) (sch :: Schema tn fn) (ts :: [Fi
 -- RECORDS
 -- -------
 
-instance (All (ProtoBridgeField sch) args, ProtoBridgeFields sch args)
-         => ProtoBridgeTerm sch ('DRecord name anns args) where
+instance (All (ProtoBridgeField sch name) args, ProtoBridgeFields sch name args)
+         => ProtoBridgeTerm sch ('DRecord name args) where
   termToProto (TRecord fields) = go fields
-    where go :: forall fs. All (ProtoBridgeField sch) fs
+    where go :: forall fs. All (ProtoBridgeField sch name) fs
              => NP (Field sch) fs -> PBEnc.MessageBuilder
           go Nil       = mempty
-          go (f :* fs) = fieldToProto f <> go fs
-  protoToTerm = TRecord <$> protoToFields
+          go (f :* fs) = fieldToProto @_ @_ @_ @name f <> go fs
+  protoToTerm = TRecord <$> protoToFields @_ @name
 
-class ProtoBridgeFields sch fields where
+class ProtoBridgeFields sch ty fields where
   protoToFields :: PBDec.Parser PBDec.RawMessage (NP (Field sch) fields)
-instance ProtoBridgeFields sch '[] where
+instance ProtoBridgeFields sch ty '[] where
   protoToFields = pure Nil
-instance (ProtoBridgeField sch f, ProtoBridgeFields sch fs)
-         => ProtoBridgeFields sch (f ': fs) where
-  protoToFields = (:*) <$> protoToField <*> protoToFields
+instance (ProtoBridgeField sch ty f, ProtoBridgeFields sch ty fs)
+         => ProtoBridgeFields sch ty (f ': fs) where
+  protoToFields = (:*) <$> protoToField @_ @_ @_ @ty <*> protoToFields @_ @ty
 
-instance ProtoBridgeTerm sch ('DRecord name anns args)
-         => ProtoBridgeEmbedTerm sch ('DRecord name anns args) where
+instance ProtoBridgeTerm sch ('DRecord name args)
+         => ProtoBridgeEmbedTerm sch ('DRecord name args) where
   termToEmbedProto fid v = PBEnc.embedded fid (termToProto v)
   embedProtoToFieldValue = do
-    t <- PBDec.embedded (protoToTerm @_ @_ @sch @('DRecord name anns args))
+    t <- PBDec.embedded (protoToTerm @_ @_ @sch @('DRecord name args))
     case t of
       Nothing -> PBDec.Parser (\_ -> Left (PBDec.WireTypeError "expected message"))
       Just v  -> return v
-  embedProtoToOneFieldValue = PBDec.embedded' (protoToTerm @_ @_ @sch @('DRecord name anns args))
+  embedProtoToOneFieldValue = PBDec.embedded' (protoToTerm @_ @_ @sch @('DRecord name args))
 
 -- ENUMERATIONS
 -- ------------
 
 instance TypeError ('Text "protobuf requires wrapping enums in a message")
-         => ProtoBridgeTerm sch ('DEnum name anns choices) where
+         => ProtoBridgeTerm sch ('DEnum name choices) where
   termToProto = error "protobuf requires wrapping enums in a message"
   protoToTerm = error "protobuf requires wrapping enums in a message"
 
-instance ProtoBridgeEnum choices
-         => ProtoBridgeEmbedTerm sch ('DEnum name anns choices) where
-  termToEmbedProto fid (TEnum v) = enumToProto fid v
+instance ProtoBridgeEnum sch name choices
+         => ProtoBridgeEmbedTerm sch ('DEnum name choices) where
+  termToEmbedProto fid (TEnum v) = enumToProto @sch @name fid v
   embedProtoToFieldValue    = do n <- PBDec.one PBDec.int32 0
-                                 TEnum <$> protoToEnum n
+                                 TEnum <$> protoToEnum @sch @name n
   embedProtoToOneFieldValue = do n <- PBDec.int32
-                                 TEnum <$> protoToEnum n
+                                 TEnum <$> protoToEnum @sch @name n
 
-class ProtoBridgeEnum (choices :: [ChoiceDef fn]) where
+class ProtoBridgeEnum sch ty (choices :: [ChoiceDef fn]) where
   enumToProto :: FieldNumber -> NS Proxy choices -> PBEnc.MessageBuilder
   protoToEnum :: Int32 -> PBDec.Parser a (NS Proxy choices)
-instance ProtoBridgeEnum '[] where
+instance ProtoBridgeEnum sch ty '[] where
   enumToProto = error "empty enum"
   protoToEnum _ = PBDec.Parser (\_ -> Left (PBDec.WireTypeError "unknown enum type"))
-instance (KnownNat (FindProtoBufId c anns), ProtoBridgeEnum cs)
-         => ProtoBridgeEnum ('ChoiceDef c anns ': cs) where
+instance (KnownNat (FindProtoBufId sch ty c), ProtoBridgeEnum sch ty cs)
+         => ProtoBridgeEnum sch ty ('ChoiceDef c ': cs) where
   enumToProto fid (Z _) = PBEnc.int32 fid enumValue
-    where enumValue = fromIntegral (natVal (Proxy @(FindProtoBufId c anns)))
-  enumToProto fid (S v) = enumToProto fid v
+    where enumValue = fromIntegral (natVal (Proxy @(FindProtoBufId sch ty c)))
+  enumToProto fid (S v) = enumToProto @sch @ty fid v
   protoToEnum n
     | n == enumValue = return (Z Proxy)
-    | otherwise      = S <$> protoToEnum n
-    where enumValue = fromIntegral (natVal (Proxy @(FindProtoBufId c anns)))
+    | otherwise      = S <$> protoToEnum @sch @ty n
+    where enumValue = fromIntegral (natVal (Proxy @(FindProtoBufId sch ty c)))
 
 -- SIMPLE
 -- ------
@@ -221,18 +231,18 @@ instance TypeError ('Text "protobuf requires wrapping primitives in a message")
 -- ---------
 
 instance {-# OVERLAPPABLE #-}
-         (ProtoBridgeFieldValue sch t, KnownNat (FindProtoBufId name anns))
-         => ProtoBridgeField sch ('FieldDef name anns t) where
+         (ProtoBridgeFieldValue sch t, KnownNat (FindProtoBufId sch ty name))
+         => ProtoBridgeField sch ty ('FieldDef name t) where
   fieldToProto (Field v) = fieldValueToProto fieldId v
-    where fieldId = fromInteger $ natVal (Proxy @(FindProtoBufId name anns))
+    where fieldId = fromInteger $ natVal (Proxy @(FindProtoBufId sch ty name))
   protoToField = Field <$> protoToFieldValue `at` fieldId
-    where fieldId = fromInteger $ natVal (Proxy @(FindProtoBufId name anns))
+    where fieldId = fromInteger $ natVal (Proxy @(FindProtoBufId sch ty name))
 
 instance {-# OVERLAPS #-}
-         (ProtoBridgeUnionFieldValue (FindProtoBufOneOfIds name anns) sch ts)
-         => ProtoBridgeField sch ('FieldDef name anns ('TUnion ts)) where
-  fieldToProto (Field (FUnion v)) = unionFieldValueToProto @_ @_ @(FindProtoBufOneOfIds name anns) v
-  protoToField = Field . FUnion <$> protoToUnionFieldValue @_ @_ @(FindProtoBufOneOfIds name anns)
+         (ProtoBridgeUnionFieldValue (FindProtoBufOneOfIds sch ty name) sch ts)
+         => ProtoBridgeField sch ty ('FieldDef name ('TUnion ts)) where
+  fieldToProto (Field (FUnion v)) = unionFieldValueToProto @_ @_ @(FindProtoBufOneOfIds sch ty name) v
+  protoToField = Field . FUnion <$> protoToUnionFieldValue @_ @_ @(FindProtoBufOneOfIds sch ty name)
 
 -- ------------------
 -- TYPES OF FIELDS --

--- a/adapter/protobuf/src/Mu/Adapter/ProtoBuf/Example.hs
+++ b/adapter/protobuf/src/Mu/Adapter/ProtoBuf/Example.hs
@@ -1,18 +1,9 @@
-{-# language DataKinds   #-}
-{-# language QuasiQuotes #-}
+{-# language DataKinds       #-}
+{-# language TemplateHaskell #-}
+{-# language TypeFamilies    #-}
 module Mu.Adapter.ProtoBuf.Example where
 
 import           Mu.Quasi.ProtoBuf
 
-type ExampleProtoBufSchema = [protobuf|
-enum gender {
-  male      = 1;
-  female    = 2;
-  nonbinary = 3;
-}
-message person {
-  repeated string names = 1;
-  int age = 2;
-  gender gender = 3;
-}
-|]
+protobuf "ExampleProtoBufSchema"  "test/protobuf/example.proto"
+protobuf "Example2ProtoBufSchema" "test/protobuf/example2.proto"

--- a/adapter/protobuf/src/Mu/Quasi/GRpc.hs
+++ b/adapter/protobuf/src/Mu/Quasi/GRpc.hs
@@ -32,7 +32,7 @@ grpc schemaName servicePrefix fp
          Left e
            -> fail ("could not parse protocol buffers spec: " ++ show e)
          Right p
-           -> protobufToDecls schemaName servicePrefix p
+           -> grpcToDecls schemaName servicePrefix p
 
 -- | Obtains a schema and service definition from Compendium,
 --   and generates the declarations from 'grpc'.
@@ -46,14 +46,14 @@ compendium schemaTypeName servicePrefix baseUrl identifier
          Left e
            -> fail ("could not parse protocol buffers spec: " ++ show e)
          Right p
-           -> protobufToDecls schemaTypeName servicePrefix p
+           -> grpcToDecls schemaTypeName servicePrefix p
 
-protobufToDecls :: String -> (String -> String) -> P.ProtoBuf -> Q [Dec]
-protobufToDecls schemaName servicePrefix p@P.ProtoBuf { P.package = pkg, P.services = srvs }
+grpcToDecls :: String -> (String -> String) -> P.ProtoBuf -> Q [Dec]
+grpcToDecls schemaName servicePrefix p@P.ProtoBuf { P.package = pkg, P.services = srvs }
   = do let schemaName' = mkName schemaName
-       schemaDec <- tySynD schemaName' [] (schemaFromProtoBuf p)
+       schemaDec <- protobufToDecls schemaName p
        serviceTy <- mapM (pbServiceDeclToDec servicePrefix pkg schemaName') srvs
-       return (schemaDec : serviceTy)
+       return (schemaDec ++ serviceTy)
 
 pbServiceDeclToDec :: (String -> String) -> Maybe [T.Text] -> Name -> P.ServiceDeclaration -> Q Dec
 pbServiceDeclToDec servicePrefix pkg schema srv@(P.Service nm _ _)

--- a/adapter/protobuf/src/Mu/Quasi/ProtoBuf.hs
+++ b/adapter/protobuf/src/Mu/Quasi/ProtoBuf.hs
@@ -1,3 +1,4 @@
+{-# language CPP             #-}
 {-# language DataKinds       #-}
 {-# language LambdaCase      #-}
 {-# language NamedFieldPuns  #-}
@@ -39,8 +40,14 @@ protobufToDecls schemaName p
   = do let schemaName' = mkName schemaName
        (schTy, annTy) <- schemaFromProtoBuf p
        schemaDec <- tySynD schemaName' [] (return schTy)
+#if MIN_VERSION_template_haskell(2,15,0)
+       annDec <- tySynInstD (tySynEqn Nothing
+                               [t| AnnotatedSchema ProtoBufAnnotation $(conT schemaName') |]
+                               (return annTy))
+#else
        annDec <- tySynInstD ''AnnotatedSchema
                    (tySynEqn [ [t| ProtoBufAnnotation |], conT schemaName' ] (return annTy))
+#endif
        return [schemaDec, annDec]
 
 schemaFromProtoBuf :: P.ProtoBuf -> Q (Type, Type)

--- a/adapter/protobuf/test/ProtoBuf.hs
+++ b/adapter/protobuf/test/ProtoBuf.hs
@@ -1,6 +1,8 @@
+{-# language DataKinds           #-}
 {-# language OverloadedStrings   #-}
 {-# language ScopedTypeVariables #-}
 {-# language TypeApplications    #-}
+{-# language TypeFamilies        #-}
 module Main where
 
 import qualified Data.ByteString      as BS
@@ -10,8 +12,20 @@ import qualified Proto3.Wire.Encode   as PBEnc
 import           System.Environment
 
 import           Mu.Adapter.ProtoBuf
-import           Mu.Schema            ()
+import           Mu.Schema
 import           Mu.Schema.Examples
+
+type instance AnnotatedSchema ProtoBufAnnotation ExampleSchema
+  = '[ 'AnnField "gender" "male"   ('ProtoBufId 1)
+     , 'AnnField "gender" "female" ('ProtoBufId 2)
+     , 'AnnField "gender" "nb"     ('ProtoBufId 3)
+     , 'AnnField "address" "postcode" ('ProtoBufId 1)
+     , 'AnnField "address" "country"  ('ProtoBufId 2)
+     , 'AnnField "person" "firstName" ('ProtoBufId 1)
+     , 'AnnField "person" "lastName"  ('ProtoBufId 2)
+     , 'AnnField "person" "age"       ('ProtoBufId 3)
+     , 'AnnField "person" "gender"    ('ProtoBufId 4)
+     , 'AnnField "person" "address"   ('ProtoBufId 5) ]
 
 exampleAddress :: Address
 exampleAddress = Address "1111BB" "Spain"

--- a/adapter/protobuf/test/protobuf/example2.proto
+++ b/adapter/protobuf/test/protobuf/example2.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+enum gender {
+  male      = 1;
+  female    = 2;
+  nonbinary = 3;
+}
+message person {
+  repeated string names = 1;
+  int32 age = 2;
+  gender gender = 3;
+}

--- a/core/rpc/src/Mu/Rpc.hs
+++ b/core/rpc/src/Mu/Rpc.hs
@@ -9,7 +9,7 @@
 -- | Protocol-independent declaration of services
 module Mu.Rpc (
   Service', Service(..)
-, Annotation, Package, FindPackageName
+, ServiceAnnotation, Package, FindPackageName
 , Method(..), (:-->:)
 , TypeRef(..), Argument(..), Return(..)
 ) where
@@ -22,23 +22,24 @@ import           Mu.Schema
 import           Mu.Schema.Registry
 
 type Service' = Service Symbol Symbol
+type ServiceAnnotation = Type
 
 -- | A service is a set of methods.
 data Service serviceName methodName
-  = Service serviceName [Annotation] [Method methodName]
+  = Service serviceName [ServiceAnnotation] [Method methodName]
 
 -- | An annotation to define a package name.
 --   This is used by some handlers, like gRPC.
 data Package (s :: Symbol)
 
-type family FindPackageName (anns :: [Annotation]) :: Symbol where
+type family FindPackageName (anns :: [ServiceAnnotation]) :: Symbol where
   FindPackageName '[] = TypeError ('Text "Cannot find package name for the service")
   FindPackageName (Package s ': rest) = s
   FindPackageName (other     ': rest) = FindPackageName rest
 
 -- | A method is defined by its name, arguments, and return type.
 data Method methodName
-  = Method methodName [Annotation] [Argument] Return
+  = Method methodName [ServiceAnnotation] [Argument] Return
 
 -- | Look up a method in a service definition using its name.
 --   Useful to declare handlers like @HandlerIO (MyService :-->: "MyMethod")@.

--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -25,12 +25,12 @@ import           Mu.Server
 -- https://grpc.io/docs/quickstart/python/
 
 type QuickstartSchema
-  = '[ 'DRecord "HelloRequest" '[]
-               '[ 'FieldDef "name" '[ ProtoBufId 1 ] ('TPrimitive T.Text) ]
-     , 'DRecord "HelloResponse" '[]
-                '[ 'FieldDef "message" '[ ProtoBufId 1 ] ('TPrimitive T.Text) ]
-     , 'DRecord "HiRequest" '[]
-               '[ 'FieldDef "number" '[ ProtoBufId 1 ] ('TPrimitive Int) ]
+  = '[ 'DRecord "HelloRequest"
+               '[ 'FieldDef "name" ('TPrimitive T.Text) ]
+     , 'DRecord "HelloResponse"
+                '[ 'FieldDef "message" ('TPrimitive T.Text) ]
+     , 'DRecord "HiRequest"
+               '[ 'FieldDef "number" ('TPrimitive Int) ]
      ]
 
 type QuickStartService

--- a/core/schema/src/Mu/Schema.hs
+++ b/core/schema/src/Mu/Schema.hs
@@ -3,7 +3,7 @@
 module Mu.Schema (
   -- * Schema definition
   Schema, Schema'
-, Annotation, KnownName(..)
+, KnownName(..)
 , TypeDef, TypeDefB(..)
 , ChoiceDef(..)
 , FieldDef, FieldDefB(..)
@@ -18,7 +18,7 @@ module Mu.Schema (
   -- ** Mappings between fields
 , Mapping(..), Mappings, MappingRight, MappingLeft
   -- ** Field annotations
-, ProtoBufId, ProtoBufOneOfIds
+, AnnotatedSchema, AnnotationDomain, Annotation(..)
 ) where
 
 import           Mu.Schema.Annotations

--- a/core/schema/src/Mu/Schema/Annotations.hs
+++ b/core/schema/src/Mu/Schema/Annotations.hs
@@ -1,10 +1,49 @@
-{-# language DataKinds      #-}
-{-# language KindSignatures #-}
+{-# language DataKinds            #-}
+{-# language GADTs                #-}
+{-# language PolyKinds            #-}
+{-# language TypeFamilies         #-}
+{-# language TypeOperators        #-}
+{-# language UndecidableInstances #-}
 module Mu.Schema.Annotations where
 
+import           Data.Kind
 import           GHC.TypeLits
 
--- ANNOTATION FOR CONVERSION
+import           Mu.Schema.Definition
 
-data ProtoBufId (n :: Nat)
-data ProtoBufOneOfIds (ns :: [Nat])
+-- | Libraries can define custom annotations.
+--   Each annotation belongs to a domain.
+type AnnotationDomain = Type
+
+-- | Libraries can define custom annotations
+--   to indicate additional information.
+data Annotation domain typeName fieldName where
+  AnnSchema :: domain
+            -> Annotation domain typeName fieldName
+  AnnType   :: typeName -> domain
+            -> Annotation domain typeName fieldName
+  AnnField  :: typeName -> fieldName -> domain
+            -> Annotation domain typeName fieldName
+
+-- | This type family links each schema to
+--   its corresponding annotations from one domain.
+type family AnnotatedSchema domain (sch :: Schema typeName fieldName)
+  :: [Annotation domain typeName fieldName]
+
+type family GetSchemaAnnotation (anns :: [Annotation domain t f]) :: domain where
+  GetSchemaAnnotation '[]
+    = TypeError ('Text "cannot find schema annotation")
+  GetSchemaAnnotation ('AnnSchema d ': rs) = d
+  GetSchemaAnnotation (r            ': rs) = GetSchemaAnnotation rs
+
+type family GetTypeAnnotation (anns :: [Annotation domain t f]) (ty :: t) :: domain where
+  GetTypeAnnotation '[] ty
+    = TypeError ('Text "cannot find annotation for " ':<>: 'ShowType ty)
+  GetTypeAnnotation ('AnnType ty d ': rs) ty = d
+  GetTypeAnnotation (r ': rs) ty = GetTypeAnnotation rs ty
+
+type family GetFieldAnnotation (anns :: [Annotation domain t f]) (ty :: t) (fl :: f) :: domain where
+  GetFieldAnnotation '[] ty fl
+    = TypeError ('Text "cannot find annotation for " ':<>: 'ShowType ty ':<>: 'Text "/" ':<>: 'ShowType fl)
+  GetFieldAnnotation ('AnnField ty fl d ': rs) ty fl = d
+  GetFieldAnnotation (r                 ': rs) ty fl = GetFieldAnnotation rs ty fl

--- a/core/schema/src/Mu/Schema/Class.hs
+++ b/core/schema/src/Mu/Schema/Class.hs
@@ -105,13 +105,13 @@ type family FindSel (xs :: * -> *) (x :: Symbol) :: Where where
 
 type family FindEnumChoice (xs :: [ChoiceDef fs]) (x :: fs) :: Where where
   FindEnumChoice '[] x = TypeError ('Text "Could not find enum choice " ':<>: 'ShowType x)
-  FindEnumChoice ('ChoiceDef name anns ': xs) name = 'Here
-  FindEnumChoice (other                ': xs) name = 'There (FindEnumChoice xs name)
+  FindEnumChoice ('ChoiceDef name ': xs) name = 'Here
+  FindEnumChoice (other           ': xs) name = 'There (FindEnumChoice xs name)
 
 type family FindField (xs :: [FieldDef ts fs]) (x :: fs) :: Where where
   FindField '[] x = TypeError ('Text "Could not find field " ':<>: 'ShowType x)
-  FindField ('FieldDef name anns t ': xs) name = 'Here
-  FindField (other                 ': xs) name = 'There (FindField xs name)
+  FindField ('FieldDef name t ': xs) name = 'Here
+  FindField (other            ': xs) name = 'There (FindField xs name)
 
 -- Generic type definitions
 class GSchemaTypeDef (sch :: Schema ts fs) (fmap :: Mappings Symbol fs)
@@ -207,6 +207,7 @@ instance (GSchemaFieldType sch t v)
          => GSchemaFieldTypeUnion sch '[t] (K1 i v) where
   toSchemaFieldTypeUnion   (K1 x) = Z (toSchemaFieldType x)
   fromSchemaFieldTypeUnion (Z x)  = K1 (fromSchemaFieldType x)
+  fromSchemaFieldTypeUnion (S _)  = error "this should never happen"
 instance (GSchemaFieldType sch t v, GSchemaFieldTypeUnion sch ts vs)
          => GSchemaFieldTypeUnion sch (t ': ts) (K1 i v :+: vs) where
   toSchemaFieldTypeUnion (L1 (K1 x)) = Z (toSchemaFieldType x)
@@ -230,14 +231,14 @@ instance (GSchemaFieldType sch t1 v1, GSchemaFieldType sch t2 v2, GSchemaFieldTy
 
 instance {-# OVERLAPPABLE #-}
          (GToSchemaEnumDecompose fmap choices f, GFromSchemaEnumDecompose fmap choices f)
-         => GSchemaTypeDef sch fmap ('DEnum name anns choices) f where
+         => GSchemaTypeDef sch fmap ('DEnum name choices) f where
   toSchemaTypeDef p x = TEnum (toSchemaEnumDecomp p x)
   fromSchemaTypeDef p (TEnum x) = fromSchemaEnumDecomp p x
 -- This instance removes unneeded metadata from the
 -- top of the type.
 instance {-# OVERLAPS #-}
-         GSchemaTypeDef sch fmap ('DEnum name anns choices) f
-         => GSchemaTypeDef sch fmap ('DEnum name anns choices) (D1 meta f) where
+         GSchemaTypeDef sch fmap ('DEnum name choices) f
+         => GSchemaTypeDef sch fmap ('DEnum name choices) (D1 meta f) where
   toSchemaTypeDef p (M1 x) = toSchemaTypeDef p x
   fromSchemaTypeDef p x = M1 (fromSchemaTypeDef p x)
 
@@ -282,7 +283,7 @@ class GFromSchemaEnumDecompose (fmap :: Mappings Symbol fs) (choices :: [ChoiceD
 instance GFromSchemaEnumDecompose fmap '[] f where
   fromSchemaEnumDecomp _ _ = error "This should never happen"
 instance (GFromSchemaEnumU1 f (FindCon f (MappingLeft fmap c)), GFromSchemaEnumDecompose fmap cs f)
-         => GFromSchemaEnumDecompose fmap ('ChoiceDef c anns ': cs) f where
+         => GFromSchemaEnumDecompose fmap ('ChoiceDef c ': cs) f where
   fromSchemaEnumDecomp _ (Z _) = fromSchemaEnumU1 (Proxy @f) (Proxy @(FindCon f (MappingLeft fmap c)))
   fromSchemaEnumDecomp p (S x) = fromSchemaEnumDecomp p x
 
@@ -302,19 +303,19 @@ instance forall other rest w. GFromSchemaEnumU1 rest w
 
 instance {-# OVERLAPPABLE #-}
          (GToSchemaRecord sch fmap args f, GFromSchemaRecord sch fmap args f)
-         => GSchemaTypeDef sch fmap ('DRecord name anns args) f where
+         => GSchemaTypeDef sch fmap ('DRecord name args) f where
   toSchemaTypeDef p x = TRecord (toSchemaRecord p x)
   fromSchemaTypeDef p (TRecord x) = fromSchemaRecord p x
 -- This instance removes unneeded metadata from the
 -- top of the type.
 instance {-# OVERLAPS #-}
-         GSchemaTypeDef sch fmap ('DRecord name anns args) f
-         => GSchemaTypeDef sch fmap ('DRecord name anns args) (D1 meta f) where
+         GSchemaTypeDef sch fmap ('DRecord name args) f
+         => GSchemaTypeDef sch fmap ('DRecord name args) (D1 meta f) where
   toSchemaTypeDef p (M1 x) = toSchemaTypeDef p x
   fromSchemaTypeDef p x = M1 (fromSchemaTypeDef p x)
 instance {-# OVERLAPS #-}
-         GSchemaTypeDef sch fmap ('DRecord name anns args) f
-         => GSchemaTypeDef sch fmap ('DRecord name anns args) (C1 meta f) where
+         GSchemaTypeDef sch fmap ('DRecord name args) f
+         => GSchemaTypeDef sch fmap ('DRecord name args) (C1 meta f) where
   toSchemaTypeDef p (M1 x) = toSchemaTypeDef p x
   fromSchemaTypeDef p x = M1 (fromSchemaTypeDef p x)
 
@@ -338,7 +339,7 @@ instance GToSchemaRecord sch fmap '[] f where
   toSchemaRecord _ _ = Nil
 instance ( GToSchemaRecord sch fmap cs f
          , GToSchemaRecordSearch sch t f (FindSel f (MappingLeft fmap name)) )
-         => GToSchemaRecord sch fmap ('FieldDef name anns t ': cs) f where
+         => GToSchemaRecord sch fmap ('FieldDef name t ': cs) f where
   toSchemaRecord p x = this  :* toSchemaRecord p x
     where this = Field (toSchemaRecordSearch (Proxy @(FindSel f (MappingLeft fmap name))) x)
 
@@ -383,7 +384,7 @@ instance GFromSchemaRecord sch fmap args U1 where
 
 class GFromSchemaRecordSearch (sch :: Schema ts fs) (v :: *) (args :: [FieldDef ts fs]) (w :: Where) where
   fromSchemaRecordSearch :: Proxy w -> NP (Field sch) args -> v
-instance GSchemaFieldType sch t v => GFromSchemaRecordSearch sch v ('FieldDef name anns t ': rest) 'Here where
+instance GSchemaFieldType sch t v => GFromSchemaRecordSearch sch v ('FieldDef name t ': rest) 'Here where
   fromSchemaRecordSearch _ (Field x :* _) = fromSchemaFieldType x
 instance forall sch v other rest n.
          GFromSchemaRecordSearch sch v rest n

--- a/core/schema/src/Mu/Schema/Conversion/TypesToSchema.hs
+++ b/core/schema/src/Mu/Schema/Conversion/TypesToSchema.hs
@@ -44,8 +44,8 @@ type family SchemaFromTypes' (all :: [FromType tn fn]) (f :: [FromType tn fn]) :
 
 type family TypeDefFromType (all :: [FromType tn fn]) (info :: FromType tn fn)
   :: TypeDef tn fn where
-  TypeDefFromType all ('AsRecord' t name mp) = 'DRecord name '[] (FieldsFromType  all mp (Rep t))
-  TypeDefFromType all ('AsEnum'   t name mp) = 'DEnum   name '[] (ChoicesFromType all mp (Rep t))
+  TypeDefFromType all ('AsRecord' t name mp) = 'DRecord name (FieldsFromType  all mp (Rep t))
+  TypeDefFromType all ('AsEnum'   t name mp) = 'DEnum   name (ChoicesFromType all mp (Rep t))
 
 type family FieldsFromType (all :: [FromType tn fn]) (mp :: Mappings Symbol fn) (f :: * -> *)
   :: [FieldDef tn fn] where
@@ -58,7 +58,7 @@ type family FieldsFromType (all :: [FromType tn fn]) (mp :: Mappings Symbol fn) 
   FieldsFromType all mp (x :*: y)
     = ConcatList (FieldsFromType all mp x) (FieldsFromType all mp y)
   FieldsFromType all mp (S1 ('MetaSel ('Just x) u ss ds) (K1 i t))
-    = '[ 'FieldDef (MappingRight mp x) '[] (ChooseFieldType all t) ]
+    = '[ 'FieldDef (MappingRight mp x) (ChooseFieldType all t) ]
   FieldsFromType all mp v
     = TypeError ('Text "unsupported conversion from " ':<>: 'ShowType v ':<>: 'Text " to record schema")
 
@@ -99,7 +99,7 @@ type family ChoicesFromType (all :: [FromType tn fn]) (mp :: Mappings Symbol fn)
   ChoicesFromType all mp (x :+: y)
     = ConcatList (ChoicesFromType all mp x) (ChoicesFromType all mp y)
   ChoicesFromType all mp (C1 ('MetaCons cname p s) U1)
-    = '[ 'ChoiceDef (MappingRight mp cname) '[] ]  -- go through constructor info
+    = '[ 'ChoiceDef (MappingRight mp cname) ]  -- go through constructor info
   ChoicesFromType all mp (C1 ('MetaCons cname p s) f)
     = TypeError ('Text "constructor " ':<>: 'ShowType cname ':<>: 'Text "has fields and cannot be turned into an enumeration schema")
   ChoicesFromType all mp v

--- a/core/schema/src/Mu/Schema/Examples.hs
+++ b/core/schema/src/Mu/Schema/Examples.hs
@@ -48,19 +48,19 @@ data Gender = Male | Female | NonBinary
 
 -- Schema for these data types
 type ExampleSchema
-  = '[ 'DEnum   "gender" '[]
-               '[ 'ChoiceDef "male"   '[ ProtoBufId 1 ]
-                , 'ChoiceDef "female" '[ ProtoBufId 2 ]
-                , 'ChoiceDef "nb"     '[ ProtoBufId 3 ] ]
-     , 'DRecord "address" '[]
-               '[ 'FieldDef "postcode" '[ ProtoBufId 1 ] ('TPrimitive T.Text)
-                , 'FieldDef "country"  '[ ProtoBufId 2 ] ('TPrimitive T.Text) ]
-     , 'DRecord "person" '[]
-                '[ 'FieldDef "firstName" '[ ProtoBufId 1 ] ('TPrimitive T.Text)
-                 , 'FieldDef "lastName"  '[ ProtoBufId 2 ] ('TPrimitive T.Text)
-                 , 'FieldDef "age"       '[ ProtoBufId 3 ] ('TOption ('TPrimitive Int))
-                 , 'FieldDef "gender"    '[ ProtoBufId 4 ] ('TOption ('TSchematic "gender"))
-                 , 'FieldDef "address"   '[ ProtoBufId 5 ] ('TSchematic "address") ]
+  = '[ 'DEnum   "gender"
+               '[ 'ChoiceDef "male"
+                , 'ChoiceDef "female"
+                , 'ChoiceDef "nb" ]
+     , 'DRecord "address"
+               '[ 'FieldDef "postcode" ('TPrimitive T.Text)
+                , 'FieldDef "country"  ('TPrimitive T.Text) ]
+     , 'DRecord "person"
+                '[ 'FieldDef "firstName" ('TPrimitive T.Text)
+                 , 'FieldDef "lastName"  ('TPrimitive T.Text)
+                 , 'FieldDef "age"       ('TOption ('TPrimitive Int))
+                 , 'FieldDef "gender"    ('TOption ('TSchematic "gender"))
+                 , 'FieldDef "address"   ('TSchematic "address") ]
      ]
 
 type GenderFieldMapping
@@ -81,19 +81,19 @@ type ExampleSchema2
                      , AsEnum Gender "gender" ]
 -}
 type ExampleSchema2
-  = '[ 'DEnum   "gender" '[]
-               '[ 'ChoiceDef "Male"      '[ ProtoBufId 1 ]
-                , 'ChoiceDef "Female"    '[ ProtoBufId 2 ]
-                , 'ChoiceDef "NonBinary" '[ ProtoBufId 3 ] ]
-     , 'DRecord "address" '[]
-               '[ 'FieldDef "postcode" '[ ProtoBufId 1 ] ('TPrimitive T.Text)
-                , 'FieldDef "country"  '[ ProtoBufId 2 ] ('TPrimitive T.Text) ]
-     , 'DRecord "person" '[]
-                '[ 'FieldDef "firstName" '[ ProtoBufId 1 ] ('TPrimitive T.Text)
-                 , 'FieldDef "lastName"  '[ ProtoBufId 2 ] ('TPrimitive T.Text)
-                 , 'FieldDef "age"       '[ ProtoBufId 3 ] ('TOption ('TPrimitive Int))
-                 , 'FieldDef "gender"    '[ ProtoBufId 4 ] ('TOption ('TSchematic "gender"))
-                 , 'FieldDef "address"   '[ ProtoBufId 5 ] ('TSchematic "address") ]
+  = '[ 'DEnum   "gender"
+               '[ 'ChoiceDef "Male"
+                , 'ChoiceDef "Female"
+                , 'ChoiceDef "NonBinary" ]
+     , 'DRecord "address"
+               '[ 'FieldDef "postcode" ('TPrimitive T.Text)
+                , 'FieldDef "country"  ('TPrimitive T.Text) ]
+     , 'DRecord "person"
+                '[ 'FieldDef "firstName" ('TPrimitive T.Text)
+                 , 'FieldDef "lastName"  ('TPrimitive T.Text)
+                 , 'FieldDef "age"       ('TOption ('TPrimitive Int))
+                 , 'FieldDef "gender"    ('TOption ('TSchematic "gender"))
+                 , 'FieldDef "address"   ('TSchematic "address") ]
      ]
 
 type ExampleRegistry

--- a/core/schema/src/Mu/Schema/Interpretation.hs
+++ b/core/schema/src/Mu/Schema/Interpretation.hs
@@ -22,13 +22,13 @@ import           Mu.Schema.Definition
 
 -- | Interpretation of a type in a schema.
 data Term (sch :: Schema typeName fieldName) (t :: TypeDef typeName fieldName) where
-  TRecord :: NP (Field sch) args -> Term sch ('DRecord name anns args)
-  TEnum   :: NS Proxy choices    -> Term sch ('DEnum name anns choices)
+  TRecord :: NP (Field sch) args -> Term sch ('DRecord name args)
+  TEnum   :: NS Proxy choices    -> Term sch ('DEnum name choices)
   TSimple :: FieldValue sch t    -> Term sch ('DSimple t)
 
 -- | Interpretation of a field.
 data Field (sch :: Schema typeName fieldName) (f :: FieldDef typeName fieldName) where
-  Field :: FieldValue sch t -> Field sch ('FieldDef name anns t)
+  Field :: FieldValue sch t -> Field sch ('FieldDef name t)
 
 -- | Interpretation of a field type, by giving a value of that type.
 data FieldValue (sch :: Schema typeName fieldName) (t :: FieldType typeName) where
@@ -50,20 +50,20 @@ data FieldValue (sch :: Schema typeName fieldName) (t :: FieldType typeName) whe
 -- ===========================
 
 instance All (Eq `Compose` Field sch) args
-         => Eq (Term sch ('DRecord name anns args)) where
+         => Eq (Term sch ('DRecord name args)) where
   TRecord xs == TRecord ys = xs == ys
 instance (KnownName name, All (Show `Compose` Field sch) args)
-         => Show (Term sch ('DRecord name anns args)) where
+         => Show (Term sch ('DRecord name args)) where
   show (TRecord xs) = "record " ++ nameVal (Proxy @name) ++ " { " ++ printFields xs ++ " }"
     where printFields :: forall fs. All (Show `Compose` Field sch) fs
                       => NP (Field sch) fs -> String
           printFields Nil         = ""
           printFields (x :* Nil)  = show x
           printFields (x :* rest) = show x ++ ", " ++ printFields rest
-instance All (Eq `Compose` Proxy) choices => Eq (Term sch ('DEnum name anns choices)) where
+instance All (Eq `Compose` Proxy) choices => Eq (Term sch ('DEnum name choices)) where
   TEnum x == TEnum y = x == y
 instance (KnownName name, All KnownName choices, All (Show `Compose` Proxy) choices)
-         => Show (Term sch ('DEnum name anns choices)) where
+         => Show (Term sch ('DEnum name choices)) where
   show (TEnum choice) = "enum " ++ nameVal (Proxy @name) ++ " { " ++ printChoice choice ++ " }"
     where printChoice :: forall cs. All KnownName cs => NS Proxy cs -> String
           printChoice (Z p) = nameVal p
@@ -73,10 +73,10 @@ instance Eq (FieldValue sch t) => Eq (Term sch ('DSimple t)) where
 instance Show (FieldValue sch t) => Show (Term sch ('DSimple t)) where
   show (TSimple x) = show x
 
-instance Eq (FieldValue sch t) => Eq (Field sch ('FieldDef name anns t)) where
+instance Eq (FieldValue sch t) => Eq (Field sch ('FieldDef name t)) where
   Field x == Field y = x == y
 instance (KnownName name, Show (FieldValue sch t))
-         => Show (Field sch ('FieldDef name anns t)) where
+         => Show (Field sch ('FieldDef name t)) where
   show (Field x) = nameVal (Proxy @name) ++ ": " ++ show x
 
 instance Eq (FieldValue sch 'TNull) where

--- a/core/schema/src/Mu/Schema/Interpretation/Anonymous.hs
+++ b/core/schema/src/Mu/Schema/Interpretation/Anonymous.hs
@@ -14,60 +14,60 @@ import           Data.SOP
 import           Mu.Schema
 
 data V0 sch sty where
-  V0 :: (sch :/: sty ~ 'DRecord nm anns '[])
+  V0 :: (sch :/: sty ~ 'DRecord nm '[])
      => V0 sch sty
 
 deriving instance Show (V0 sch sty)
 deriving instance Eq   (V0 sch sty)
 deriving instance Ord  (V0 sch sty)
 
-instance (sch :/: sty ~ 'DRecord nm anns '[])
+instance (sch :/: sty ~ 'DRecord nm '[])
          => HasSchema sch sty (V0 sch sty) where
   toSchema V0 = TRecord Nil
   fromSchema (TRecord Nil) = V0
 
 data V1 sch sty where
   V1 :: (sch :/: sty
-           ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a) ])
+           ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a) ])
      => a -> V1 sch sty
 
 deriving instance (Show a, sch :/: sty
-                             ~ 'DRecord anns nm '[ 'FieldDef f fanns ('TPrimitive a) ])
+                             ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a) ])
                   => Show (V1 sch sty)
 deriving instance (Eq a, sch :/: sty
-                          ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a) ])
+                          ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a) ])
                   => Eq (V1 sch sty)
 deriving instance (Ord a, sch :/: sty
-                            ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a) ])
+                            ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a) ])
                   => Ord (V1 sch sty)
 
 instance (sch :/: sty
-            ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a) ])
+            ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a) ])
          => HasSchema sch sty (V1 sch sty) where
   toSchema (V1 x) = TRecord (Field (FPrimitive x) :* Nil)
   fromSchema (TRecord (Field (FPrimitive x) :* Nil)) = V1 x
 
 data V2 sch sty where
   V2 :: (sch :/: sty
-           ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a)
-                               , 'FieldDef g ganns ('TPrimitive b) ])
+           ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a)
+                          , 'FieldDef g ('TPrimitive b) ])
      => a -> b -> V2 sch sty
 
 deriving instance (Show a, Show b,
-                   sch :/: sty ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a)
-                                                   , 'FieldDef g ganns ('TPrimitive b) ])
+                   sch :/: sty ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a)
+                                              , 'FieldDef g ('TPrimitive b) ])
                   => Show (V2 sch sty)
 deriving instance (Eq a, Eq b,
-                   sch :/: sty ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a)
-                                                   , 'FieldDef g ganns ('TPrimitive b) ])
+                   sch :/: sty ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a)
+                                              , 'FieldDef g ('TPrimitive b) ])
                   => Eq (V2 sch sty)
 deriving instance (Ord a, Ord b,
-                   sch :/: sty ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a)
-                                                   , 'FieldDef g ganns ('TPrimitive b) ])
+                   sch :/: sty ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a)
+                                              , 'FieldDef g ('TPrimitive b) ])
                   => Ord (V2 sch sty)
 
-instance (sch :/: sty ~ 'DRecord nm anns '[ 'FieldDef f fanns ('TPrimitive a)
-                                         , 'FieldDef g ganns ('TPrimitive b) ])
+instance (sch :/: sty ~ 'DRecord nm '[ 'FieldDef f ('TPrimitive a)
+                                     , 'FieldDef g ('TPrimitive b) ])
          => HasSchema sch sty (V2 sch sty) where
   toSchema (V2 x y) = TRecord (Field (FPrimitive x) :* Field (FPrimitive y) :* Nil)
   fromSchema (TRecord (Field (FPrimitive x) :* Field (FPrimitive y) :* Nil)) = V2 x y

--- a/examples/seed/src/Schema.hs
+++ b/examples/seed/src/Schema.hs
@@ -7,6 +7,7 @@
 {-# language MultiParamTypeClasses #-}
 {-# language PolyKinds             #-}
 {-# language TemplateHaskell       #-}
+{-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
 
 module Schema where

--- a/examples/todolist/src/Definition.hs
+++ b/examples/todolist/src/Definition.hs
@@ -9,6 +9,7 @@
 {-# language TemplateHaskell       #-}
 {-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
+
 module Definition where
 
 import           Data.Int
@@ -18,7 +19,7 @@ import           GHC.Generics
 import           Mu.Quasi.GRpc
 import           Mu.Schema
 
-$(grpc "TodoListSchema" id "todolist.proto")
+grpc "TodoListSchema" id "todolist.proto"
 
 newtype MessageId = MessageId
   { value :: Int32

--- a/examples/todolist/src/Definition.hs
+++ b/examples/todolist/src/Definition.hs
@@ -9,7 +9,6 @@
 {-# language TemplateHaskell       #-}
 {-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
-
 module Definition where
 
 import           Data.Int
@@ -19,7 +18,7 @@ import           GHC.Generics
 import           Mu.Quasi.GRpc
 import           Mu.Schema
 
-grpc "TodoListSchema" id "todolist.proto"
+$(grpc "TodoListSchema" id "todolist.proto")
 
 newtype MessageId = MessageId
   { value :: Int32

--- a/examples/todolist/src/Definition.hs
+++ b/examples/todolist/src/Definition.hs
@@ -7,6 +7,7 @@
 {-# language MultiParamTypeClasses #-}
 {-# language PolyKinds             #-}
 {-# language TemplateHaskell       #-}
+{-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
 
 module Definition where

--- a/grpc/client/src/Mu/GRpc/Client/Examples.hs
+++ b/grpc/client/src/Mu/GRpc/Client/Examples.hs
@@ -1,5 +1,6 @@
 {-# language DataKinds        #-}
 {-# language TypeApplications #-}
+{-# language TypeFamilies     #-}
 module Mu.GRpc.Client.Examples where
 
 import           Data.Conduit
@@ -8,8 +9,15 @@ import           Data.Conduit.List        (consume)
 import qualified Data.Text                as T
 import           Network.HTTP2.Client     (HostName, PortNumber)
 
+import           Mu.Adapter.ProtoBuf
 import           Mu.GRpc.Client.TyApps
 import           Mu.Rpc.Examples
+import           Mu.Schema
+
+type instance AnnotatedSchema ProtoBufAnnotation QuickstartSchema
+  = '[ 'AnnField "HelloRequest" "name" ('ProtoBufId 1)
+     , 'AnnField "HelloResponse" "message" ('ProtoBufId 1)
+     , 'AnnField "HiRequest" "number" ('ProtoBufId 1) ]
 
 sayHello' :: HostName -> PortNumber -> T.Text -> IO (GRpcReply T.Text)
 sayHello' host port req

--- a/grpc/client/src/Mu/GRpc/Client/Record.hs
+++ b/grpc/client/src/Mu/GRpc/Client/Record.hs
@@ -44,7 +44,7 @@ import           Mu.Rpc
 -- | Fills in a Haskell record of functions with the corresponding
 --   calls to gRPC services from a Mu 'Service' declaration.
 buildService :: forall (s :: Service') (p :: Symbol) t
-                (nm :: Symbol) (anns :: [Annotation]) (ms :: [Method Symbol]).
+                (nm :: Symbol) (anns :: [ServiceAnnotation]) (ms :: [Method Symbol]).
                 (s ~ 'Service nm anns ms, Generic t, BuildService s p ms (Rep t))
              => GrpcClient -> t
 buildService client = to (buildService' (Proxy @s) (Proxy @p) (Proxy @ms) client)

--- a/grpc/server/src/ExampleServer.hs
+++ b/grpc/server/src/ExampleServer.hs
@@ -1,8 +1,17 @@
+{-# language DataKinds         #-}
 {-# language OverloadedStrings #-}
+{-# language TypeFamilies      #-}
 module Main where
 
+import           Mu.Adapter.ProtoBuf
 import           Mu.GRpc.Server
 import           Mu.Rpc.Examples
+import           Mu.Schema
+
+type instance AnnotatedSchema ProtoBufAnnotation QuickstartSchema
+  = '[ 'AnnField "HelloRequest" "name" ('ProtoBufId 1)
+     , 'AnnField "HelloResponse" "message" ('ProtoBufId 1)
+     , 'AnnField "HiRequest" "number" ('ProtoBufId 1) ]
 
 main :: IO ()
 main = do

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-11-17
+resolver: nightly-2019-11-29
 allow-newer: true
 
 packages:

--- a/templates/grpc-server.hsfiles
+++ b/templates/grpc-server.hsfiles
@@ -73,6 +73,7 @@ service Service {
 {-# language MultiParamTypeClasses #-}
 {-# language PolyKinds             #-}
 {-# language TemplateHaskell       #-}
+{-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
 module Schema where
 


### PR DESCRIPTION
Before definitions like the id for ProtoBuf were part of the schema. However, that meant that we could not retro-fit the same schema for different purposes. This PR separates these two concepts and updates the Template Haskell code, so examples don't need to change.

This change will be properly documented in #31 