### PR TITLE
Add recommended vscode extensions! 💻

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "DigitalAssetHoldingsLLC.ghcide",
+    "hoovercj.haskell-linter",
+    "vigoo.stylish-haskell",
+    "EditorConfig.EditorConfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": true
-}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,6 +3,7 @@
 Before continuing, make sure you've read:
 
 - [Alejandro's post on setting up a Haskell development environment](https://www.47deg.com/blog/setting-up-haskell/).
+- [Kowainik's Haskell Style Guide](https://kowainik.github.io/posts/2019-02-06-style-guide).
 
 ## VSCode extensions
 
@@ -21,6 +22,16 @@ Regarding the formatter, we use the `master` version of [stylish-haskell](https:
 $ git clone https://github.com/jaspervdj/stylish-haskell
 $ ...
 $ cd stylish-haskell && stack install
+```
+
+We don't provide any git hook or tool that enforces our style. However, before you propose any PR please make sure to run `stylish-haskell` yourself, and to follow our style guide mentioned above to the extent possible. 😊
+
+If you wan't to automate this for your VSCode, add the following to your `.vscode/settings.json`:
+
+```json
+{
+  "editor.formatOnSave": true
+}
 ```
 
 Happy hacking! 👏🏼


### PR DESCRIPTION
Apparently this is a new feature of **vscode**, and when you open a project with this settings a prompt appears asking you to auto-install the recommended extensions! 👏  I think this behaviour is quite handy and will help the new contributors to follow https://github.com/higherkindness/mu-haskell/blob/master/DEVELOPMENT.md 😉 