### PR TITLE
Update dependencies

### DIFF
--- a/adapter/protobuf/src/Mu/Adapter/ProtoBuf.hs
+++ b/adapter/protobuf/src/Mu/Adapter/ProtoBuf.hs
@@ -1,4 +1,5 @@
 {-# language AllowAmbiguousTypes   #-}
+{-# language CPP                   #-}
 {-# language ConstraintKinds       #-}
 {-# language DataKinds             #-}
 {-# language FlexibleContexts      #-}
@@ -44,6 +45,10 @@ import           Mu.Schema.Class
 import           Mu.Schema.Definition
 import           Mu.Schema.Interpretation
 import qualified Mu.Schema.Registry       as R
+
+#if MIN_VERSION_proto3_wire(1,1,0)
+instance ProtoEnum Bool
+#endif
 
 data ProtoBufAnnotation
   = ProtoBufId Nat

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-11-29
+resolver: nightly-2019-12-12
 allow-newer: true
 
 packages:
@@ -17,7 +17,7 @@ packages:
 extra-deps:
 - http2-client-0.9.0.0
 - http2-grpc-types-0.5.0.0
-- proto3-wire-1.0.0
+- proto3-wire-1.1.0
 - http2-grpc-proto3-wire-0.1.0.0
 - warp-grpc-0.2.0.0
 - http2-client-grpc-0.8.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
-resolver: lts-14.14
+resolver: lts-14.17
+allow-newer: true
 
 packages:
 - core/schema
@@ -16,7 +17,7 @@ packages:
 extra-deps:
 - http2-client-0.9.0.0
 - http2-grpc-types-0.5.0.0
-- proto3-wire-1.0.0
+- proto3-wire-1.1.0
 - http2-grpc-proto3-wire-0.1.0.0
 - warp-grpc-0.2.0.0
 - http2-client-grpc-0.8.0.0


### PR DESCRIPTION
The new `proto3-wire` version 1.1 needs a small instance for `Bool`.