### PR TITLE
Make ghcide happy

### DIFF
--- a/adapter/avro/hie.yaml
+++ b/adapter/avro/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-avro:lib" } }

--- a/adapter/avro/src/Mu/Adapter/Avro/Example.hs
+++ b/adapter/avro/src/Mu/Adapter/Avro/Example.hs
@@ -1,3 +1,4 @@
+{-# language CPP         #-}
 {-# language DataKinds   #-}
 {-# language QuasiQuotes #-}
 
@@ -35,4 +36,8 @@ type Example = [avro|
 }
 |]
 
+#if __GHCIDE__
+type ExampleFromFile = [avroFile|adapter/avro/test/avro/example.avsc|]
+#else
 type ExampleFromFile = [avroFile|test/avro/example.avsc|]
+#endif

--- a/adapter/persistent/hie.yaml
+++ b/adapter/persistent/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-persistent:lib" } }

--- a/adapter/protobuf/hie.yaml
+++ b/adapter/protobuf/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-protobuf:lib" } }

--- a/adapter/protobuf/src/Mu/Adapter/ProtoBuf/Example.hs
+++ b/adapter/protobuf/src/Mu/Adapter/ProtoBuf/Example.hs
@@ -1,3 +1,4 @@
+{-# language CPP             #-}
 {-# language DataKinds       #-}
 {-# language TemplateHaskell #-}
 {-# language TypeFamilies    #-}
@@ -5,5 +6,10 @@ module Mu.Adapter.ProtoBuf.Example where
 
 import           Mu.Quasi.ProtoBuf
 
+#if __GHCIDE__
+protobuf "ExampleProtoBufSchema"  "adapter/protobuf/test/protobuf/example.proto"
+protobuf "Example2ProtoBufSchema" "adapter/protobuf/test/protobuf/example2.proto"
+#else
 protobuf "ExampleProtoBufSchema"  "test/protobuf/example.proto"
 protobuf "Example2ProtoBufSchema" "test/protobuf/example2.proto"
+#endif

--- a/compendium-client/hie.yaml
+++ b/compendium-client/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "compendium-client:lib" } }

--- a/core/rpc/hie.yaml
+++ b/core/rpc/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-rpc:lib" } }

--- a/core/schema/hie.yaml
+++ b/core/schema/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-schema:lib" } }

--- a/examples/health-check/hie.yaml
+++ b/examples/health-check/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-example-health-check:exe:health-server" } }

--- a/examples/health-check/mu-example-health-check.cabal
+++ b/examples/health-check/mu-example-health-check.cabal
@@ -16,17 +16,6 @@ copyright:           Copyright © 2019-2020 47 Degrees. <http://47deg.com>
 category:            Network
 build-type:          Simple
 
-library
-  exposed-modules:     Definition
-  build-depends:       base >=4.12 && <5, text,
-                       mu-schema, mu-rpc, mu-protobuf,
-                       stm, stm-containers,
-                       conduit, stm-conduit,
-                       deferred-folds
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -Wall
-
 executable health-server
   main-is:             Server.hs
   other-modules:       Definition

--- a/examples/health-check/src/Definition.hs
+++ b/examples/health-check/src/Definition.hs
@@ -1,3 +1,4 @@
+{-# language CPP                   #-}
 {-# language DataKinds             #-}
 {-# language DeriveAnyClass        #-}
 {-# language DeriveGeneric         #-}
@@ -18,7 +19,11 @@ import           GHC.Generics
 import           Mu.Quasi.GRpc
 import           Mu.Schema
 
+#if __GHCIDE__
+grpc "HealthCheckSchema" id "examples/health-check/healthcheck.proto"
+#else
 grpc "HealthCheckSchema" id "healthcheck.proto"
+#endif
 
 newtype HealthCheckMsg
   = HealthCheckMsg { nameService :: Maybe T.Text }

--- a/examples/route-guide/hie.yaml
+++ b/examples/route-guide/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-example-route-guide:exe:route-guide-server" } }

--- a/examples/route-guide/mu-example-route-guide.cabal
+++ b/examples/route-guide/mu-example-route-guide.cabal
@@ -16,15 +16,6 @@ copyright:           Copyright © 2019-2020 47 Degrees. <http://47deg.com>
 category:            Network
 build-type:          Simple
 
-library
-  exposed-modules:     Definition
-  build-depends:       base >=4.12 && <5, text,
-                       mu-schema, mu-rpc, mu-protobuf,
-                       hashable
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -Wall
-
 executable route-guide-server
   main-is:             Server.hs
   other-modules:       Definition

--- a/examples/route-guide/src/Definition.hs
+++ b/examples/route-guide/src/Definition.hs
@@ -1,3 +1,4 @@
+{-# language CPP                   #-}
 {-# language DataKinds             #-}
 {-# language DeriveAnyClass        #-}
 {-# language DeriveGeneric         #-}
@@ -19,7 +20,11 @@ import           GHC.Generics
 import           Mu.Quasi.GRpc
 import           Mu.Schema
 
+#if __GHCIDE__
+grpc "RouteGuideSchema" id "examples/route-guide/routeguide.proto"
+#else
 grpc "RouteGuideSchema" id "routeguide.proto"
+#endif
 
 data Point
   = Point { latitude, longitude :: Maybe Int32 }

--- a/examples/seed/hie.yaml
+++ b/examples/seed/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-example-seed:exe:seed-server" } }

--- a/examples/seed/src/Schema.hs
+++ b/examples/seed/src/Schema.hs
@@ -1,3 +1,4 @@
+{-# language CPP                   #-}
 {-# language DataKinds             #-}
 {-# language DeriveAnyClass        #-}
 {-# language DeriveGeneric         #-}
@@ -19,7 +20,11 @@ import           GHC.Generics
 import           Mu.Quasi.GRpc
 import           Mu.Schema
 
+#if __GHCIDE__
+grpc "SeedSchema" id "examples/seed/seed.proto"
+#else
 grpc "SeedSchema" id "seed.proto"
+#endif
 
 data Person = Person
   { name :: Maybe T.Text

--- a/examples/todolist/hie.yaml
+++ b/examples/todolist/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-example-todolist:exe:todolist-server" } }

--- a/examples/todolist/mu-example-todolist.cabal
+++ b/examples/todolist/mu-example-todolist.cabal
@@ -16,18 +16,6 @@ copyright:           Copyright © 2019-2020 47 Degrees. <http://47deg.com>
 category:            Network
 build-type:          Simple
 
-library
-  exposed-modules:     Definition
-  build-depends:       base >=4.12 && <5
-                     , text
-                     , mu-schema
-                     , mu-rpc
-                     , mu-protobuf
-                     , hashable
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-  ghc-options:         -Wall
-
 executable todolist-server
   main-is:             Server.hs
   other-modules:       Definition

--- a/examples/todolist/src/Definition.hs
+++ b/examples/todolist/src/Definition.hs
@@ -1,3 +1,4 @@
+{-# language CPP                   #-}
 {-# language DataKinds             #-}
 {-# language DeriveAnyClass        #-}
 {-# language DeriveGeneric         #-}
@@ -18,7 +19,11 @@ import           GHC.Generics
 import           Mu.Quasi.GRpc
 import           Mu.Schema
 
+#if __GHCIDE__
+grpc "TodoListSchema" id "examples/todolist/todolist.proto"
+#else
 grpc "TodoListSchema" id "todolist.proto"
+#endif
 
 newtype MessageId = MessageId
   { value :: Maybe Int32

--- a/examples/with-persistent/hie.yaml
+++ b/examples/with-persistent/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-example-with-persistent:exe:persistent-server" } }

--- a/examples/with-persistent/src/Schema.hs
+++ b/examples/with-persistent/src/Schema.hs
@@ -1,3 +1,4 @@
+{-# language CPP                        #-}
 {-# language DataKinds                  #-}
 {-# language DeriveGeneric              #-}
 {-# language DerivingVia                #-}
@@ -29,7 +30,11 @@ import           Mu.Adapter.Persistent   (WithEntityNestedId (..))
 import           Mu.Quasi.GRpc
 import           Mu.Schema
 
+#if __GHCIDE__
+grpc "PersistentSchema" id "examples/with-persistent/with-persistent.proto"
+#else
 grpc "PersistentSchema" id "with-persistent.proto"
+#endif
 
 newtype MPersonRequest = MPersonRequest
   { identifier :: Maybe Int64

--- a/grpc/client/hie.yaml
+++ b/grpc/client/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-grpc-client:lib" } }

--- a/grpc/server/hie.yaml
+++ b/grpc/server/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-grpc-server:lib" } }


### PR DESCRIPTION
This PR adds a `hie.yaml` file to each package, which instructs `ghcide` about which packages to load in each case. In addition, it uses the new `__GHCIDE__` macro to use different paths during IDE operation and type checking.