### PR TITLE
[WIP] Add link to GitHub and API docs

### DIFF
--- a/docs/_includes/_doc.html
+++ b/docs/_includes/_doc.html
@@ -8,10 +8,14 @@
           <img src="{{ site.baseurl }}/img/sidebar-icon-open.svg" alt="Toggle">
       </button>
 
-      <ul>
-        <li class="nav-menu-item"><a href="https://github.com/higherkindness/mu-haskell">GitHub</a></li>
-        <li class="nav-menu-item"><a href="{{ 'haddock/index.html' | relative_url }}">API Docs</a></li>
-      </ul>
+      <div class="link-container">
+        <div class="link-item">
+          <a href="{{ 'haddock/index.html' | relative_url }}">API Docs</a>
+        </div>
+        <div class="link-item">
+          <a href="https://github.com/higherkindness/mu-haskell">GitHub</a>
+        </div>
+      </div>
 
     </div>
     <div class="doc-content">

--- a/docs/_includes/_doc.html
+++ b/docs/_includes/_doc.html
@@ -7,6 +7,12 @@
         title="Toggle">
           <img src="{{ site.baseurl }}/img/sidebar-icon-open.svg" alt="Toggle">
       </button>
+
+      <ul>
+        <li class="nav-menu-item"><a href="https://github.com/higherkindness/mu-haskell">GitHub</a></li>
+        <li class="nav-menu-item"><a href="{{ 'haddock/index.html' | relative_url }}">API Docs</a></li>
+      </ul>
+
     </div>
     <div class="doc-content">
         {{ content }}

--- a/docs/_sass/components/_doc.scss
+++ b/docs/_sass/components/_doc.scss
@@ -33,23 +33,15 @@
         }
       }
 
-      ul {
+      .link-container {
         display: flex;
-        justify-content: space-between;
-        flex-direction: row;
+        height: 100%;
+        width: 100%;
+        justify-content: flex-end;
+        align-items: center;
 
-        .nav-menu-item {
-            padding: ($base-point-grid * 2);
-            margin: ($base-point-grid * 2);
-            list-style-type: none;
-
-            a {
-                color: $gray-primary;
-                &:hover {
-                  color: rgba($brand-primary, 0.96);
-                  text-decoration: none;
-                }
-            }
+        .link-item {
+          margin-left: ($base-point-grid * 2);
         }
       }
     }

--- a/docs/_sass/components/_doc.scss
+++ b/docs/_sass/components/_doc.scss
@@ -32,6 +32,26 @@
           margin: ($base-point-grid * 2);
         }
       }
+
+      ul {
+        display: flex;
+        justify-content: space-between;
+        flex-direction: row;
+
+        .nav-menu-item {
+            padding: ($base-point-grid * 2);
+            margin: ($base-point-grid * 2);
+            list-style-type: none;
+
+            a {
+                color: $gray-primary;
+                &:hover {
+                  color: rgba($brand-primary, 0.96);
+                  text-decoration: none;
+                }
+            }
+        }
+      }
     }
 
     .doc-content {


### PR DESCRIPTION
The documentation should include links to the GitHub repo (better with the amount of watchers and stars) and to the API docs.

This is a very rough attempt on my side. @calvellido could you have a look at it and push any required change to this branch?