### PR TITLE
Various fixes to make gRPC server work

### DIFF
--- a/grpc/server/mu-grpc-server.cabal
+++ b/grpc/server/mu-grpc-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                mu-grpc-server
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            gRPC servers for Mu definitions
 description:         With @mu-grpc-server@ you can easily build gRPC servers for mu-haskell!
 license:             Apache-2.0

--- a/grpc/server/mu-grpc-server.cabal
+++ b/grpc/server/mu-grpc-server.cabal
@@ -34,7 +34,7 @@ library
                      , stm
                      , stm-conduit
                      , wai
-                     , warp
+                     , warp < 3.3
                      , warp-grpc
                      , warp-tls
   hs-source-dirs:      src
@@ -59,7 +59,7 @@ executable grpc-example-server
                      , stm
                      , stm-conduit
                      , wai
-                     , warp
+                     , warp < 3.3
                      , warp-grpc
                      , warp-tls
   hs-source-dirs:      src

--- a/templates/grpc-server.hsfiles
+++ b/templates/grpc-server.hsfiles
@@ -25,14 +25,14 @@ executable {{name}}
                        mu-grpc-server
 
 {-# START_FILE stack.yaml #-}
-resolver: lts-14.20
+resolver: lts-14.17
 allow-newer: true
 extra-deps:
 # mu
 - mu-schema-0.1.0.0
 - mu-rpc-0.1.0.0
 - mu-protobuf-0.1.0.0
-- mu-grpc-server-0.1.0.0
+- mu-grpc-server-0.1.0.1
 - compendium-client-0.1.0.1
 # dependencies of mu
 - http2-client-0.9.0.0


### PR DESCRIPTION
* Better capture and rethrow exceptions
* Make clear that Warp 3.3 is not supported
* Update template to generate a working example