### PR TITLE
Set decimal as list-style for ordered lists

### DIFF
--- a/docs/_sass/components/_doc.scss
+++ b/docs/_sass/components/_doc.scss
@@ -99,12 +99,17 @@
         margin: ($base-point-grid * 2) 0;
     }
 
-    ul {
-        padding-left: 20px;
+    ol, ul {
+        padding-left: ($base-point-grid * 4);
         margin-bottom: ($base-point-grid * 2);
-        li {
-            list-style: disc;
-        }
+    }
+
+    ol li {
+      list-style: decimal;
+    }
+
+    ul li {
+      list-style: disc;
     }
 
     .header-link {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/7753447/73165131-81f88580-40f3-11ea-9f4c-48eecf135adb.png)



After:

![image](https://user-images.githubusercontent.com/7753447/73165091-6db48880-40f3-11ea-9fae-bb09f1004bea.png)


This fixes #93 