### PR TITLE
Add a CI job to test the Stack templates

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,3 +10,33 @@ jobs:
       with:
         name: 47deg
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
+  test_stack_templates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mstksg/setup-stack@v1
+
+      - uses: actions/checkout@v1
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.stack
+          key: dot-stack-${{ hashFiles('templates/*.hsfiles') }}
+          restore-keys: |
+            dot-stack-
+
+      - name: Generate Avro RPC server from Stack template
+        run: stack new muhaskellavro https://raw.githubusercontent.com/higherkindness/mu-haskell/master/templates/grpc-server-avro.hsfiles -p "author-email:haskell.curry@47deg.com" -p "author-name:Haskell Curry"
+        working-directory: /tmp
+
+      - name: Build the generated Avro RPC server
+        run: stack build
+        working-directory: /tmp/muhaskellavro
+
+      - name: Generate Protobuf RPC server from Stack template
+        run: stack new muhaskellprotobuf https://raw.githubusercontent.com/higherkindness/mu-haskell/master/templates/grpc-server-protobuf.hsfiles -p "author-email:haskell.curry@47deg.com" -p "author-name:Haskell Curry"
+        working-directory: /tmp
+
+      - name: Build the generated Protobuf RPC server
+        run: stack build
+        working-directory: /tmp/muhaskellprotobuf


### PR DESCRIPTION
The first run takes about 15 minutes to download and compile the world, but subsequent runs will take about 2 minutes because `~/.stack` is cached.