### PR TITLE
Update to warp-grpc 0.4 and fix multi-servers

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
-{ nixpkgs ? (fetchTarball https://github.com/NixOS/nixpkgs/archive/484ea7bbac5bf7f958b0bb314a3c130b6c328800.tar.gz)
-, pkgs ? import nixpkgs (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/3db580a.tar.gz))
+{ nixpkgs ? (fetchTarball https://github.com/NixOS/nixpkgs/archive/3578bb5.tar.gz)
+, pkgs ? import nixpkgs (import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/350b594.tar.gz))
 }:
 
 let

--- a/examples/health-check/mu-example-health-check.cabal
+++ b/examples/health-check/mu-example-health-check.cabal
@@ -21,7 +21,8 @@ executable health-server
   main-is:          Server.hs
   other-modules:    Definition
   build-depends:
-      base            >=4.12  && <5
+      async
+    , base            >=4.12  && <5
     , conduit
     , deferred-folds
     , mu-graphql
@@ -34,8 +35,6 @@ executable health-server
     , stm-containers
     , text
     , wai
-    , wai-route
-    , warp
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/examples/seed/mu-example-seed.cabal
+++ b/examples/seed/mu-example-seed.cabal
@@ -27,7 +27,8 @@ executable seed-server
   other-modules:    Schema
   default-language: Haskell2010
   build-depends:
-      base            >=4.12  && <5
+      async
+    , base            >=4.12  && <5
     , conduit
     , monad-logger
     , mu-graphql
@@ -38,8 +39,6 @@ executable seed-server
     , stm
     , text
     , wai
-    , wai-route
-    , warp
 
 executable seed-server-optics
   hs-source-dirs:   src

--- a/examples/seed/src/Main.hs
+++ b/examples/seed/src/Main.hs
@@ -51,7 +51,7 @@ main = do
   putStrLn "running seed application"
   runConcurrently $ (\_ _ _ -> ())
     <$> Concurrently (runGRpcAppTrans msgProtoBuf 8080 runStderrLoggingT server)
-    <*> Concurrently (runGRpcAppTrans msgAvro     8080 runStderrLoggingT server)
+    <*> Concurrently (runGRpcAppTrans msgAvro     8081 runStderrLoggingT server)
     <*> Concurrently (runGraphQLAppTrans         50053 runStderrLoggingT server
                         (Proxy @('Just "PeopleService"))
                         (Proxy @'Nothing) (Proxy @'Nothing))

--- a/examples/seed/src/Main.hs
+++ b/examples/seed/src/Main.hs
@@ -11,6 +11,7 @@
 module Main where
 
 import           Control.Concurrent       (threadDelay)
+import           Control.Concurrent.Async
 import           Control.Monad.IO.Class   (liftIO)
 import           Control.Monad.Logger
 import           Data.Conduit
@@ -23,8 +24,6 @@ import           Mu.GRpc.Server
 import           Mu.Schema
 import           Mu.Server
 import           Network.Wai
-import           Network.Wai.Handler.Warp
-import           Network.Wai.Route
 
 import           Schema
 
@@ -50,14 +49,11 @@ newtype PeopleResponse = PeopleResponse
 main :: IO ()
 main = do
   putStrLn "running seed application"
-  run 8080 $ flip route app404 $ compileRoutes
-    [ defRoute (str "proto" ./ end) $
-        \_ -> gRpcAppTrans msgProtoBuf runStderrLoggingT server
-    , defRoute (str "avro" ./ end) $
-        \_ -> gRpcAppTrans msgAvro runStderrLoggingT server
-    , defRoute (str "graphql" ./ end) $
-        \_ -> graphQLAppTransQuery runStderrLoggingT server (Proxy @"PeopleService")
-    ]
+  runConcurrently $ (\_ _ _ -> ())
+    <$> Concurrently (runGRpcAppTrans msgProtoBuf 8080 runStderrLoggingT server)
+    <*> Concurrently (runGRpcAppTrans msgAvro     8080 runStderrLoggingT server)
+    <*> Concurrently (runGraphQLAppTrans         50053 runStderrLoggingT server
+                        (Proxy @('Just "PeopleService")) (Proxy @'Nothing))
 
 
 -- Server implementation

--- a/graphql/src/Mu/GraphQL/Server.hs
+++ b/graphql/src/Mu/GraphQL/Server.hs
@@ -13,6 +13,8 @@ module Mu.GraphQL.Server (
   -- * Run an GraphQL resolver directly
   , runGraphQLApp
   , runGraphQLAppSettings
+  , runGraphQLAppQuery
+  , runGraphQLAppTrans
   -- * Build a WAI 'Application'
   , graphQLApp
   , graphQLAppTrans
@@ -160,3 +162,23 @@ runGraphQLApp ::
   -> Proxy mut
   -> IO ()
 runGraphQLApp port svr q m = run port (graphQLApp svr q m)
+
+-- | Run a Mu 'graphQLApp' on a transformer stack on the given port.
+runGraphQLAppTrans ::
+  ( GraphQLApp p qr mut m chn hs )
+  => Port
+  -> (forall a. m a -> ServerErrorIO a)
+  -> ServerT chn p m hs
+  -> Proxy qr
+  -> Proxy mut
+  -> IO ()
+runGraphQLAppTrans port f svr q m = run port (graphQLAppTrans f svr q m)
+
+-- | Run a query-only Mu 'graphQLApp' on the given port.
+runGraphQLAppQuery ::
+  ( GraphQLApp p ('Just qr) 'Nothing ServerErrorIO chn hs )
+  => Port
+  -> ServerT chn p ServerErrorIO hs
+  -> Proxy qr
+  -> IO ()
+runGraphQLAppQuery port svr q = run port (graphQLAppQuery svr q)

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -25,7 +25,7 @@ extra-deps:
 - http2-grpc-types-0.5.0.0
 - proto3-wire-1.1.0
 - http2-grpc-proto3-wire-0.1.0.0
-- warp-grpc-0.3.0.0
+- warp-grpc-0.4.0.0
 - http2-client-grpc-0.8.0.0
 - avro-0.4.7.0
 - language-protobuf-1.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,7 +25,7 @@ extra-deps:
 - http2-grpc-types-0.5.0.0
 - proto3-wire-1.1.0
 - http2-grpc-proto3-wire-0.1.0.0
-- warp-grpc-0.3.0.0
+- warp-grpc-0.4.0.0
 - http2-client-grpc-0.8.0.0
 - avro-0.4.7.0
 - language-protobuf-1.0.1


### PR DESCRIPTION
The initial goal was update to the new [`warp-grpc` 0.4](http://hackage.haskell.org/package/warp-grpc), which includes its own functionality to work with transformers.

While doing so, I discovered that the gRPC spec does not allow services to be served from routes, which means that the examples using `wai-route` didn't work *at all*. This PR also fixes this by running several applications concurrently on different ports.