### PR TITLE
Packed fields in Protocol Buffers

### DIFF
--- a/adapter/avro/test/Avro.hs
+++ b/adapter/avro/test/Avro.hs
@@ -18,8 +18,8 @@ exampleAddress :: Address
 exampleAddress = Address "1111BB" "Spain"
 
 examplePerson1, examplePerson2 :: Person
-examplePerson1 = Person "Haskellio" "Gomez" (Just 30) (Just Male) exampleAddress
-examplePerson2 = Person "Cuarenta" "Siete" Nothing Nothing exampleAddress
+examplePerson1 = Person "Haskellio" "Gomez" (Just 30) (Just Male) exampleAddress [1,2,3]
+examplePerson2 = Person "Cuarenta" "Siete" Nothing Nothing exampleAddress []
 
 deriving via (WithSchema ExampleSchema "person" Person) instance HasAvroSchema Person
 deriving via (WithSchema ExampleSchema "person" Person) instance FromAvro Person

--- a/adapter/avro/test/avro/example.avsc
+++ b/adapter/avro/test/avro/example.avsc
@@ -16,7 +16,8 @@
       {"name": "lastName", "type": "string"},
       {"name": "age",  "type": ["long", "null"]},
       {"name": "gender", "type": ["gender", "null"]},
-      {"name": "address", "type": "address"}
+      {"name": "address", "type": "address"},
+      {"name": "lucky_numbers", "type": { "type": "array", "items": "long" } }
     ]
   }
 ]

--- a/adapter/avro/test/avro/generate.py
+++ b/adapter/avro/test/avro/generate.py
@@ -4,8 +4,8 @@ from avro.io import DatumWriter
 import sys
 
 example_address = { "postcode": "0000AA", "country": "Nederland"}
-example_person1 = {"firstName": "Pythonio", "lastName": "van Gogh", "age": 30, "gender": "male", "address": example_address}
-example_person2 = {"firstName": "Fortyseveriano", "lastName": "van Gogh", "address": example_address}
+example_person1 = {"firstName": "Pythonio", "lastName": "van Gogh", "age": 30, "gender": "male", "address": example_address, "lucky_numbers": [1,2,3]}
+example_person2 = {"firstName": "Fortyseveriano", "lastName": "van Gogh", "address": example_address, "lucky_numbers": []}
 
 print(example_person1)
 print(example_person2)

--- a/adapter/protobuf/test/ProtoBuf.hs
+++ b/adapter/protobuf/test/ProtoBuf.hs
@@ -39,17 +39,17 @@ data MAddress
   deriving (FromSchema ExampleSchema "address")
 
 type instance AnnotatedSchema ProtoBufAnnotation ExampleSchema
-  = '[ 'AnnField "gender" "male"   ('ProtoBufId 1)
-     , 'AnnField "gender" "female" ('ProtoBufId 2)
-     , 'AnnField "gender" "nb"     ('ProtoBufId 3)
-     , 'AnnField "address" "postcode" ('ProtoBufId 1)
-     , 'AnnField "address" "country"  ('ProtoBufId 2)
-     , 'AnnField "person" "firstName" ('ProtoBufId 1)
-     , 'AnnField "person" "lastName"  ('ProtoBufId 2)
-     , 'AnnField "person" "age"       ('ProtoBufId 3)
-     , 'AnnField "person" "gender"    ('ProtoBufId 4)
-     , 'AnnField "person" "address"   ('ProtoBufId 5)
-     , 'AnnField "person" "lucky_numbers" ('ProtoBufId 6) ]
+  = '[ 'AnnField "gender" "male"   ('ProtoBufId 1 'True)
+     , 'AnnField "gender" "female" ('ProtoBufId 2 'True)
+     , 'AnnField "gender" "nb"     ('ProtoBufId 3 'True)
+     , 'AnnField "address" "postcode" ('ProtoBufId 1 'True)
+     , 'AnnField "address" "country"  ('ProtoBufId 2 'True)
+     , 'AnnField "person" "firstName" ('ProtoBufId 1 'True)
+     , 'AnnField "person" "lastName"  ('ProtoBufId 2 'True)
+     , 'AnnField "person" "age"       ('ProtoBufId 3 'True)
+     , 'AnnField "person" "gender"    ('ProtoBufId 4 'True)
+     , 'AnnField "person" "address"   ('ProtoBufId 5 'True)
+     , 'AnnField "person" "lucky_numbers" ('ProtoBufId 6 'True) ]
 
 exampleAddress :: MAddress
 exampleAddress = MAddress "1111BB" "Spain"

--- a/adapter/protobuf/test/ProtoBuf.hs
+++ b/adapter/protobuf/test/ProtoBuf.hs
@@ -21,11 +21,12 @@ import           Mu.Schema
 import           Mu.Schema.Examples
 
 data MPerson
-  = MPerson { firstName :: T.Text
-            , lastName  :: T.Text
-            , age       :: Maybe Int
-            , gender    :: Maybe Gender
-            , address   :: MAddress }
+  = MPerson { firstName     :: T.Text
+            , lastName      :: T.Text
+            , age           :: Maybe Int
+            , gender        :: Maybe Gender
+            , address       :: MAddress
+            , lucky_numbers :: [Int] }
   deriving (Eq, Show, Generic)
   deriving (ToSchema ExampleSchema "person")
   deriving (FromSchema ExampleSchema "person")
@@ -47,7 +48,8 @@ type instance AnnotatedSchema ProtoBufAnnotation ExampleSchema
      , 'AnnField "person" "lastName"  ('ProtoBufId 2)
      , 'AnnField "person" "age"       ('ProtoBufId 3)
      , 'AnnField "person" "gender"    ('ProtoBufId 4)
-     , 'AnnField "person" "address"   ('ProtoBufId 5) ]
+     , 'AnnField "person" "address"   ('ProtoBufId 5)
+     , 'AnnField "person" "lucky_numbers" ('ProtoBufId 6) ]
 
 exampleAddress :: MAddress
 exampleAddress = MAddress "1111BB" "Spain"
@@ -55,10 +57,10 @@ exampleAddress = MAddress "1111BB" "Spain"
 examplePerson1, examplePerson2 :: MPerson
 examplePerson1 = MPerson "Haskellio" "Gómez"
                          (Just 30) (Just Male)
-                         exampleAddress
+                         exampleAddress [1,2,3]
 examplePerson2 = MPerson "Cuarenta" "Siete"
                          Nothing Nothing
-                         exampleAddress
+                         exampleAddress []
 
 main :: IO ()
 main = do -- Obtain the filenames

--- a/adapter/protobuf/test/protobuf/example.proto
+++ b/adapter/protobuf/test/protobuf/example.proto
@@ -6,6 +6,7 @@ message person {
   int32 age = 3;
   gender gender = 4;
   address address = 5;
+  repeated int32 lucky_numbers = 6 [packed=true];
 }
 
 message address {

--- a/adapter/protobuf/test/protobuf/example_pb2.py
+++ b/adapter/protobuf/test/protobuf/example_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\rexample.proto\"n\n\x06person\x12\x11\n\tfirstName\x18\x01 \x01(\t\x12\x10\n\x08lastName\x18\x02 \x01(\t\x12\x0b\n\x03\x61ge\x18\x03 \x01(\x05\x12\x17\n\x06gender\x18\x04 \x01(\x0e\x32\x07.gender\x12\x19\n\x07\x61\x64\x64ress\x18\x05 \x01(\x0b\x32\x08.address\",\n\x07\x61\x64\x64ress\x12\x10\n\x08postcode\x18\x01 \x01(\t\x12\x0f\n\x07\x63ountry\x18\x02 \x01(\t*&\n\x06gender\x12\x06\n\x02nb\x10\x00\x12\x08\n\x04male\x10\x01\x12\n\n\x06\x66\x65male\x10\x02\x62\x06proto3')
+  serialized_pb=_b('\n\rexample.proto\"\x89\x01\n\x06person\x12\x11\n\tfirstName\x18\x01 \x01(\t\x12\x10\n\x08lastName\x18\x02 \x01(\t\x12\x0b\n\x03\x61ge\x18\x03 \x01(\x05\x12\x17\n\x06gender\x18\x04 \x01(\x0e\x32\x07.gender\x12\x19\n\x07\x61\x64\x64ress\x18\x05 \x01(\x0b\x32\x08.address\x12\x19\n\rlucky_numbers\x18\x06 \x03(\x05\x42\x02\x10\x01\",\n\x07\x61\x64\x64ress\x12\x10\n\x08postcode\x18\x01 \x01(\t\x12\x0f\n\x07\x63ountry\x18\x02 \x01(\t*&\n\x06gender\x12\x06\n\x02nb\x10\x00\x12\x08\n\x04male\x10\x01\x12\n\n\x06\x66\x65male\x10\x02\x62\x06proto3')
 )
 
 _GENDER = _descriptor.EnumDescriptor(
@@ -45,8 +45,8 @@ _GENDER = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=175,
-  serialized_end=213,
+  serialized_start=203,
+  serialized_end=241,
 )
 _sym_db.RegisterEnumDescriptor(_GENDER)
 
@@ -99,6 +99,13 @@ _PERSON = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='lucky_numbers', full_name='person.lucky_numbers', index=5,
+      number=6, type=5, cpp_type=1, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=_b('\020\001'), file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -111,8 +118,8 @@ _PERSON = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=17,
-  serialized_end=127,
+  serialized_start=18,
+  serialized_end=155,
 )
 
 
@@ -149,8 +156,8 @@ _ADDRESS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=129,
-  serialized_end=173,
+  serialized_start=157,
+  serialized_end=201,
 )
 
 _PERSON.fields_by_name['gender'].enum_type = _GENDER
@@ -175,4 +182,5 @@ address = _reflection.GeneratedProtocolMessageType('address', (_message.Message,
 _sym_db.RegisterMessage(address)
 
 
+_PERSON.fields_by_name['lucky_numbers']._options = None
 # @@protoc_insertion_point(module_scope)

--- a/adapter/protobuf/test/protobuf/generate.py
+++ b/adapter/protobuf/test/protobuf/generate.py
@@ -9,6 +9,8 @@ example_person.firstName = "Pythonio"
 example_person.lastName = "van Gogh"
 example_person.age = 30
 example_person.gender = male
+for i in [1,2,3]:
+  example_person.lucky_numbers.append(i)
 example_person.address.CopyFrom(example_address)
 
 f = open(sys.argv[1], "wb")

--- a/core/schema/src/Mu/Schema/Examples.hs
+++ b/core/schema/src/Mu/Schema/Examples.hs
@@ -29,11 +29,12 @@ import           Mu.Schema
 import           Mu.Schema.Conversion.SchemaToTypes
 
 data Person
-  = Person { firstName :: T.Text
-           , lastName  :: T.Text
-           , age       :: Maybe Int
-           , gender    :: Maybe Gender
-           , address   :: Address }
+  = Person { firstName     :: T.Text
+           , lastName      :: T.Text
+           , age           :: Maybe Int
+           , gender        :: Maybe Gender
+           , address       :: Address
+           , lucky_numbers :: [Int] }
   deriving (Eq, Show, Generic)
   deriving (ToSchema ExampleSchema "person", FromSchema ExampleSchema "person")
   deriving (J.ToJSON, J.FromJSON)
@@ -73,7 +74,8 @@ type ExampleSchema
                  , 'FieldDef "lastName"  ('TPrimitive T.Text)
                  , 'FieldDef "age"       ('TOption ('TPrimitive Int))
                  , 'FieldDef "gender"    ('TOption ('TSchematic "gender"))
-                 , 'FieldDef "address"   ('TSchematic "address") ]
+                 , 'FieldDef "address"   ('TSchematic "address")
+                 , 'FieldDef "lucky_numbers" ('TList ('TPrimitive Int)) ]
      ]
 
 $(generateTypesFromSchema (++"Msg") ''ExampleSchema)

--- a/grpc/client/src/Mu/GRpc/Client/Examples.hs
+++ b/grpc/client/src/Mu/GRpc/Client/Examples.hs
@@ -20,9 +20,9 @@ import           Mu.Rpc.Examples
 import           Mu.Schema
 
 type instance AnnotatedSchema ProtoBufAnnotation QuickstartSchema
-  = '[ 'AnnField "HelloRequest" "name" ('ProtoBufId 1)
-     , 'AnnField "HelloResponse" "message" ('ProtoBufId 1)
-     , 'AnnField "HiRequest" "number" ('ProtoBufId 1) ]
+  = '[ 'AnnField "HelloRequest" "name" ('ProtoBufId 1 'True)
+     , 'AnnField "HelloResponse" "message" ('ProtoBufId 1 'True)
+     , 'AnnField "HiRequest" "number" ('ProtoBufId 1 'True) ]
 
 sayHello' :: HostName -> PortNumber -> T.Text -> IO (GRpcReply T.Text)
 sayHello' host port req

--- a/grpc/server/src/ExampleServer.hs
+++ b/grpc/server/src/ExampleServer.hs
@@ -9,9 +9,9 @@ import           Mu.Rpc.Examples
 import           Mu.Schema
 
 type instance AnnotatedSchema ProtoBufAnnotation QuickstartSchema
-  = '[ 'AnnField "HelloRequest" "name" ('ProtoBufId 1)
-     , 'AnnField "HelloResponse" "message" ('ProtoBufId 1)
-     , 'AnnField "HiRequest" "number" ('ProtoBufId 1) ]
+  = '[ 'AnnField "HelloRequest" "name" ('ProtoBufId 1 'True)
+     , 'AnnField "HelloResponse" "message" ('ProtoBufId 1 'True)
+     , 'AnnField "HiRequest" "number" ('ProtoBufId 1 'True) ]
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Fixes #163 @cb372 

The patch works by adding a new `supportsPacking` flag to types. If this is true, they should provide a way to parse a list of those things at once. The parser of `TList a` is aware of that, and tries to call it if possible.