### PR TITLE
Better API to declare servers

### DIFF
--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -9,6 +9,7 @@
 {-# language PartialTypeSignatures #-}
 {-# language PolyKinds             #-}
 {-# language ScopedTypeVariables   #-}
+{-# language TypeApplications      #-}
 {-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
@@ -71,7 +72,11 @@ newtype HiRequest = HiRequest { number :: Int }
 quickstartServer :: forall m. (MonadServer m)
                  => ServerT '[] QuickStartService m _
 quickstartServer
-  = Server (sayHello :<|>: sayHi :<|>: sayManyHellos :<|>: H0)
+  -- = Server (sayHello :<|>: sayHi :<|>: sayManyHellos :<|>: H0)
+  = singleService $ method @"SayHello" sayHello
+                :|: method @"SayManyHellos" sayManyHellos
+                :|: method @"SayHi" sayHi
+                :|: N0
   where
     sayHello :: HelloRequest -> m HelloResponse
     sayHello (HelloRequest nm)

--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -91,20 +91,7 @@ quickstartServer
     sayManyHellos source sink
       = runConduit $ source .| C.mapM sayHello .| sink
 
-{-
-From https://www.apollographql.com/docs/apollo-server/schema/schema/
-
-type Book {
-  title: String
-  author: Author
-}
-
-type Author {
-  name: String
-  books: [Book]
-}
--}
-
+-- From https://www.apollographql.com/docs/apollo-server/schema/schema/
 type ApolloService
   = 'Package ('Just "apollo")
       '[ Object "Book" '[]

--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -73,10 +73,9 @@ quickstartServer :: forall m. (MonadServer m)
                  => ServerT '[] QuickStartService m _
 quickstartServer
   -- = Server (sayHello :<|>: sayHi :<|>: sayManyHellos :<|>: H0)
-  = singleService $ method @"SayHello" sayHello
-                :|: method @"SayManyHellos" sayManyHellos
-                :|: method @"SayHi" sayHi
-                :|: N0
+  = singleService ( method @"SayHello" sayHello
+                  , method @"SayManyHellos" sayManyHellos
+                  , method @"SayHi" sayHi )
   where
     sayHello :: HelloRequest -> m HelloResponse
     sayHello (HelloRequest nm)
@@ -125,9 +124,11 @@ type ApolloBookAuthor = '[
 
 apolloServer :: forall m. (MonadServer m) => ServerT ApolloBookAuthor ApolloService m _
 apolloServer
-  = Services $ (pure . fst :<||>: pure . snd :<||>: H0)
-               :<&>: (authorName :<||>: authorBooks :<||>: H0)
-               :<&>: S0
+  = resolver
+      ( object @"Author" ( field @"name"   authorName
+                         , field @"books"  authorBooks )
+      , object @"Book"   ( field @"author" (pure . snd)
+                         , field @"title"  (pure . fst) ) )
   where
     authorName :: Integer -> m String
     authorName _ = pure "alex"  -- this would run in the DB

--- a/core/rpc/src/Mu/Server.hs
+++ b/core/rpc/src/Mu/Server.hs
@@ -58,7 +58,6 @@ module Mu.Server (
 import           Control.Monad.Except
 import           Data.Conduit
 import           Data.Kind
-import           GHC.TypeLits
 
 import           Mu.Rpc
 import           Mu.Schema

--- a/core/rpc/src/Mu/Server.hs
+++ b/core/rpc/src/Mu/Server.hs
@@ -57,7 +57,7 @@ module Mu.Server (
 import           Control.Monad.Except
 import           Data.Conduit
 import           Data.Kind
-import           GHC.TypeLits         (Symbol)
+import           GHC.TypeLits
 
 import           Mu.Rpc
 import           Mu.Schema
@@ -269,6 +269,15 @@ instance ToNamedList (Named n1 h1, Named n2 h2, Named n3 h3, Named n4 h4, Named 
 instance ToNamedList (Named n1 h1, Named n2 h2, Named n3 h3, Named n4 h4, Named n5 h5, Named n6 h6)
                      '[ '(n1, h1), '(n2, h2), '(n3, h3), '(n4, h4), '(n5, h5), '(n6, h6) ] where
   toNamedList (n1, n2, n3, n4, n5, n6) = n1 :|: n2 :|: n3 :|: n4 :|: n5 :|: n6 :|: N0
+instance ToNamedList (Named n1 h1, Named n2 h2, Named n3 h3, Named n4 h4, Named n5 h5, Named n6 h6, Named n7 h7)
+                     '[ '(n1, h1), '(n2, h2), '(n3, h3), '(n4, h4), '(n5, h5), '(n6, h6), '(n7, h7) ] where
+  toNamedList (n1, n2, n3, n4, n5, n6, n7) = n1 :|: n2 :|: n3 :|: n4 :|: n5 :|: n6 :|: n7 :|: N0
+instance ToNamedList (Named n1 h1, Named n2 h2, Named n3 h3, Named n4 h4, Named n5 h5, Named n6 h6, Named n7 h7, Named n8 h8)
+                     '[ '(n1, h1), '(n2, h2), '(n3, h3), '(n4, h4), '(n5, h5), '(n6, h6), '(n7, h7), '(n8, h8) ] where
+  toNamedList (n1, n2, n3, n4, n5, n6, n7, n8) = n1 :|: n2 :|: n3 :|: n4 :|: n5 :|: n6 :|: n7 :|: n8 :|: N0
+instance ToNamedList (Named n1 h1, Named n2 h2, Named n3 h3, Named n4 h4, Named n5 h5, Named n6 h6, Named n7 h7, Named n8 h8, Named n9 h9)
+                     '[ '(n1, h1), '(n2, h2), '(n3, h3), '(n4, h4), '(n5, h5), '(n6, h6), '(n7, h7), '(n8, h8), '(n9, h9) ] where
+  toNamedList (n1, n2, n3, n4, n5, n6, n7, n8, n9) = n1 :|: n2 :|: n3 :|: n4 :|: n5 :|: n6 :|: n7 :|: n8 :|: n9 :|: N0
 
 class ToHandlers chn inh ms m hs nl | chn inh ms m nl -> hs where
   toHandlers :: NamedList nl
@@ -282,11 +291,9 @@ instance (FindHandler name inh h nl, Handles chn args ret m h, ToHandlers chn in
 
 class FindHandler name inh h nl | name nl -> inh h where
   findHandler :: Proxy name -> NamedList nl -> inh -> h
-{-
-instance TypeError ('Text "cannot find handler for " ':<>: 'ShowType name)
+instance (inh ~ h, h ~ TypeError ('Text "cannot find handler for " ':<>: 'ShowType name))
          => FindHandler name inh h '[] where
   findHandler = error "this should never be called"
--}
 instance {-# OVERLAPS #-} (inh ~ inh', h ~ h')
          => FindHandler name inh h ( '(name, inh' -> h') ': rest ) where
   findHandler _ (Named f :|: _) = f
@@ -307,11 +314,9 @@ instance ( FindService name (HandlersT chn (MappingRight chn name) methods m h) 
 
 class FindService name h nl | name nl -> h where
   findService :: Proxy name -> NamedList nl -> h
-{-
-instance TypeError ('Text "cannot find handler for " ':<>: 'ShowType name)
+instance (h ~ TypeError ('Text "cannot find handler for " ':<>: 'ShowType name))
          => FindService name h '[] where
   findService = error "this should never be called"
--}
 instance {-# OVERLAPS #-} (h ~ h')
          => FindService name h ( '(name, h') ': rest ) where
   findService _ (Named f :|: _) = f

--- a/examples/health-check/src/Server.hs
+++ b/examples/health-check/src/Server.hs
@@ -41,8 +41,13 @@ type StatusMap = M.Map T.Text T.Text
 type StatusUpdates = TBMChan HealthStatusMsg
 
 server :: StatusMap -> StatusUpdates -> ServerIO HealthCheckService _
-server m upd = Server (setStatus_ m upd :<|>: checkH_ m :<|>: clearStatus_ m :<|>:
-  checkAll_ m :<|>: cleanAll_ m :<|>: watch_ upd :<|>: H0)
+server m upd
+  = singleService ( method @"setStatus"   $ setStatus_ m upd
+                  , method @"check"       $ checkH_ m
+                  , method @"clearStatus" $ clearStatus_ m
+                  , method @"checkAll"    $ checkAll_ m
+                  , method @"cleanAll"    $ cleanAll_ m
+                  , method @"watch"       $ watch_ upd)
 
 setStatus_ :: StatusMap -> StatusUpdates -> HealthStatusMsg -> ServerErrorIO ()
 setStatus_ m upd

--- a/examples/route-guide/src/Server.hs
+++ b/examples/route-guide/src/Server.hs
@@ -1,7 +1,9 @@
+{-# language DataKinds             #-}
 {-# language DuplicateRecordFields #-}
 {-# language OverloadedStrings     #-}
 {-# language PartialTypeSignatures #-}
 {-# language ScopedTypeVariables   #-}
+{-# language TypeApplications      #-}
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
 module Main where
@@ -68,8 +70,11 @@ calcDistance (Point lat1 lon1) (Point lat2 lon2)
 -- https://github.com/higherkindness/mu/blob/master/modules/examples/routeguide/server/src/main/scala/handlers/RouteGuideServiceHandler.scala
 
 server :: Features -> TBMChan RouteNote -> ServerIO RouteGuideService _
-server f m = Server
-  (getFeature f :<|>: listFeatures f  :<|>: recordRoute f :<|>: routeChat m :<|>: H0)
+server f m
+  = singleService ( method @"GetFeature"   $ getFeature f
+                  , method @"ListFeatures" $ listFeatures f
+                  , method @"RecordRoute"  $ recordRoute f
+                  , method @"RouteChat"    $ routeChat m)
 
 getFeature :: Features -> Point -> ServerErrorIO Feature
 getFeature fs p = pure $ fromMaybe nilFeature (findFeatureIn fs p)

--- a/examples/seed/src/Main.hs
+++ b/examples/seed/src/Main.hs
@@ -61,7 +61,8 @@ main = do
 -- https://github.com/higherkindness/mu/blob/master/modules/examples/seed/server/modules/process/src/main/scala/example/seed/server/process/ProtoPeopleServiceHandler.scala
 
 server :: (MonadServer m, MonadLogger m) => SingleServerT PeopleService m _
-server = Server (getPerson :<|>: getPersonStream :<|>: H0)
+server
+  = singleService (method @"getPerson" getPerson, method @"getPersonStream" getPersonStream)
 
 evolvePerson :: PeopleRequest -> PeopleResponse
 evolvePerson (PeopleRequest n) = PeopleResponse $ Just $ Person n 18

--- a/examples/todolist/src/Server.hs
+++ b/examples/todolist/src/Server.hs
@@ -2,6 +2,7 @@
 {-# language NamedFieldPuns        #-}
 {-# language OverloadedStrings     #-}
 {-# language PartialTypeSignatures #-}
+{-# language TypeApplications      #-}
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
 module Main where
@@ -31,8 +32,13 @@ type Id = TVar Int32
 type TodoList = TVar [TodoListMessage]
 
 server :: Id -> TodoList -> ServerIO TodoListService _
-server i t = Server
-  (reset i t :<|>: insert i t :<|>: retrieve t :<|>: list_ t :<|>: update t :<|>: destroy t :<|>: H0)
+server i t
+  = singleService ( method @"reset"    $ reset i t
+                  , method @"insert"   $ insert i t
+                  , method @"retrieve" $ retrieve t
+                  , method @"list"     $ list_ t
+                  , method @"update"   $ update t
+                  , method @"destroy"  $ destroy t )
 
 reset :: Id -> TodoList -> ServerErrorIO MessageId
 reset i t = alwaysOk $ do

--- a/examples/with-persistent/src/Server.hs
+++ b/examples/with-persistent/src/Server.hs
@@ -1,3 +1,4 @@
+{-# language DataKinds             #-}
 {-# language FlexibleContexts      #-}
 {-# language OverloadedStrings     #-}
 {-# language PartialTypeSignatures #-}
@@ -27,7 +28,10 @@ main = do
       liftIO $ runGRpcApp msgProtoBuf 1234 (server conn)
 
 server :: SqlBackend -> SingleServerT PersistentService ServerErrorIO _
-server p = Server (getPerson p :<|>: newPerson p :<|>: allPeople p :<|>: H0)
+server p
+  = singleService ( method @"getPerson" $ getPerson p
+                  , method @"newPerson" $ newPerson p
+                  , method @"allPeople" $ allPeople p)
 
 getPerson :: SqlBackend -> MPersonRequest -> ServerErrorIO (Entity Person)
 getPerson conn (MPersonRequest idf) = do

--- a/graphql/exe/Main.hs
+++ b/graphql/exe/Main.hs
@@ -64,15 +64,18 @@ library
 
 libraryServer :: forall m. (MonadServer m) => ServerT ServiceMapping ServiceDefinition m _
 libraryServer
-  = Services $ (bookId :<||>: bookTitle :<||>: bookAuthor :<||>: H0)
-               :<&>: (authorId :<||>: authorName :<||>: authorBooks :<||>: H0)
-               :<&>: (noContext findAuthor
-                      :<||>: noContext findBookTitle
-                      :<||>: noContext allAuthors
-                      :<||>: noContext allBooks'
-                      :<||>: H0)
-               :<&>: (noContext allBooksConduit :<||>: H0)
-               :<&>: S0
+  = resolver ( object @"Book"   ( field  @"id"      bookId
+                                , field  @"title"   bookTitle
+                                , field  @"author"  bookAuthor )
+             , object @"Author" ( field  @"id"      authorId
+                                , field  @"name"    authorName
+                                , field  @"books"   authorBooks )
+             , object @"Query"  ( method @"author"  findAuthor
+                                , method @"book"    findBookTitle
+                                , method @"authors" allAuthors
+                                , method @"books"   allBooks' )
+             , object @"Subscription" ( method @"books" allBooksConduit )
+             )
   where
     findBook i = find ((==i) . fst3) library
 


### PR DESCRIPTION
Fixes #136 

This defines a new API to build servers which does not rely on the order in which methods are declared in the type-level schema. This is mostly problematic because we expect people to *import* the schema, and the parser may not guarantee ordering (what happens if you have an import, for example?). 

```diff
quickstartServer
-  -- = Server (sayHello :<|>: sayHi :<|>: sayManyHellos :<|>: H0)
+  = singleService ( method @"SayHello" sayHello
+                  , method @"SayManyHellos" sayManyHellos
+                  , method @"SayHi" sayHi )
```