### PR TITLE
Refactor out GraphQL example helpers! 🗜

### DIFF
--- a/graphql/exe/Main.hs
+++ b/graphql/exe/Main.hs
@@ -19,8 +19,8 @@ import           Data.List                         (find)
 import           Data.Maybe                        (fromMaybe, listToMaybe)
 import           Data.Proxy
 import qualified Data.Text                         as T
-import           Text.Regex.TDFA
-import           Text.Regex.TDFA.Text              ()
+import           Text.Regex.TDFA                   ((=~))
+import           Text.Regex.TDFA.Common            (fst3, snd3, thd3)
 
 import           Network.Wai.Handler.Warp          (run)
 import           Network.Wai.Middleware.AddHeaders (addHeaders)
@@ -80,12 +80,12 @@ libraryServer
     findBook i = find ((==i) . fst3) library
 
     bookId (_, bid) = pure bid
-    bookTitle (aid, bid) = pure $ maybe "" (fromMaybe "" . lookup bid . trd3) (findBook aid)
+    bookTitle (aid, bid) = pure $ maybe "" (fromMaybe "" . lookup bid . thd3) (findBook aid)
     bookAuthor (aid, _) = pure aid
 
     authorId = pure
     authorName aid = pure $ maybe "" snd3 (findBook aid)
-    authorBooks aid = pure $ maybe [] (map ((aid,) . fst) . trd3) (findBook aid)
+    authorBooks aid = pure $ maybe [] (map ((aid,) . fst) . thd3) (findBook aid)
 
     findAuthor rx = pure $ listToMaybe
       [aid | (aid, name, _) <- library, name =~ rx]
@@ -101,14 +101,3 @@ libraryServer
 
     allBooksConduit :: ConduitM (Integer, Integer) Void m () -> m ()
     allBooksConduit sink = runConduit $ yieldMany allBooks .| sink
-
--- helpers
-
-fst3 :: (a, b, c) -> a
-fst3 (x, _, _) = x
-
-snd3 :: (a, b, c) -> b
-snd3 (_, y, _) = y
-
-trd3 :: (a, b, c) -> c
-trd3 (_, _, z) = z


### PR DESCRIPTION
Having a closer look at the code for `Text.Regex.TDFA`, I noticed they were exporting exactly the same helper functions that we were using, so I thought I'd clean up the code a bit 😉 