### PR TITLE
Add latest version of warp-grpc v0.4.0.1 🕷

### DIFF
--- a/grpc/server/mu-grpc-server.cabal
+++ b/grpc/server/mu-grpc-server.cabal
@@ -25,7 +25,7 @@ library
   build-depends:
       async
     , avro              >=0.5
-    , base              >=4.12  && <5
+    , base              >=4.12    && <5
     , binary
     , bytestring
     , conduit
@@ -40,7 +40,7 @@ library
     , stm-conduit
     , wai
     , warp
-    , warp-grpc         >=0.4
+    , warp-grpc         >=0.4.0.1
     , warp-tls
 
   hs-source-dirs:   src
@@ -53,7 +53,7 @@ executable grpc-example-server
   build-depends:
       async
     , avro              >=0.4.7
-    , base              >=4.12  && <5
+    , base              >=4.12    && <5
     , binary
     , bytestring
     , conduit
@@ -68,7 +68,7 @@ executable grpc-example-server
     , stm-conduit
     , wai
     , warp
-    , warp-grpc
+    , warp-grpc         >=0.4.0.1
     , warp-tls
 
   hs-source-dirs:   src

--- a/templates/grpc-server-avro.hsfiles
+++ b/templates/grpc-server-avro.hsfiles
@@ -43,7 +43,7 @@ extra-deps:
 - http2-client-0.9.0.0
 - http2-grpc-types-0.5.0.0
 - http2-grpc-proto3-wire-0.1.0.0
-- warp-grpc-0.4.0.0
+- warp-grpc-0.4.0.1
 - proto3-wire-1.1.0
 - language-protobuf-1.0.1
 - language-avro-0.1.3.1

--- a/templates/grpc-server-protobuf.hsfiles
+++ b/templates/grpc-server-protobuf.hsfiles
@@ -43,7 +43,7 @@ extra-deps:
 - http2-client-0.9.0.0
 - http2-grpc-types-0.5.0.0
 - http2-grpc-proto3-wire-0.1.0.0
-- warp-grpc-0.4.0.0
+- warp-grpc-0.4.0.1
 - proto3-wire-1.1.0
 - language-protobuf-1.0.1
 - language-avro-0.1.3.1


### PR DESCRIPTION
As mentioned by @cb372 in https://github.com/higherkindness/mu-haskell/pull/181#discussion_r410152040, this version contains an important fix, so here it goes! :shipit: 