### PR TITLE
Remove the Haddock hack to make it work on 0.2 and next

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         LAST_TAG=$(git describe --abbrev=0 --tags)
         git checkout $LAST_TAG
-        bash ./generate-haddock-docs.sh ocean
+        bash ./generate-haddock-docs.sh
         BUNDLE_GEMFILE=./docs/Gemfile bundle exec jekyll build -b /mu-haskell -s docs -d gen-docs
     - name: Build microsite from master
       run: |


### PR DESCRIPTION
This PR must be merged **after** we had created the 0.3 tag, and that becomes the official stable version.