### PR TITLE
Update the `avdl` Template Haskell codegen

### DIFF
--- a/adapter/avro/src/Mu/Quasi/Avro.hs
+++ b/adapter/avro/src/Mu/Quasi/Avro.hs
@@ -88,7 +88,7 @@ avdlToDecls schemaName serviceName protocol
        schemaDec <- tySynD schemaName' [] (schemaFromAvro $ S.toList (A.types protocol))
        serviceDec <- tySynD serviceName' []
          [t| 'Package $(pkgType (A.ns protocol))
-                '[ 'Service $(textToStrLit (A.pname protocol)) '[]
+                '[ 'Service $(textToStrLit (A.pname protocol))
                             $(typesToList <$> mapM (avroMethodToType schemaName')
                             (S.toList $ A.messages protocol)) ] |]
        pure [schemaDec, serviceDec]
@@ -176,13 +176,13 @@ flattenAvroDecls = concatMap (uncurry (:) . flattenDecl)
 
 avroMethodToType :: Name -> A.Method -> Q Type
 avroMethodToType schemaName m
-  = [t| 'Method $(textToStrLit (A.mname m)) '[]
+  = [t| 'Method $(textToStrLit (A.mname m))
                 $(typesToList <$> mapM argToType (A.args m))
                 $(retToType (A.result m)) |]
   where
     argToType :: A.Argument -> Q Type
     argToType (A.Argument (A.NamedType a) _)
-      = [t| 'ArgSingle 'Nothing '[] ('SchemaRef $(conT schemaName) $(textToStrLit (A.baseName a))) |]
+      = [t| 'ArgSingle 'Nothing ('SchemaRef $(conT schemaName) $(textToStrLit (A.baseName a))) |]
     argToType (A.Argument _ _)
       = fail "only named types may be used as arguments"
 

--- a/adapter/avro/src/Mu/Quasi/Avro/Example.hs
+++ b/adapter/avro/src/Mu/Quasi/Avro/Example.hs
@@ -1,6 +1,8 @@
-{-# language CPP         #-}
-{-# language DataKinds   #-}
-{-# language QuasiQuotes #-}
+{-# language CPP             #-}
+{-# language DataKinds       #-}
+{-# language QuasiQuotes     #-}
+{-# language TemplateHaskell #-}
+
 {-|
 Description : Examples for Avro quasi-quoters
 
@@ -8,7 +10,7 @@ Look at the source code of this module.
 -}
 module Mu.Quasi.Avro.Example where
 
-import           Mu.Quasi.Avro (avro, avroFile)
+import           Mu.Quasi.Avro (avdl, avro, avroFile)
 
 type Example = [avro|
 {
@@ -44,4 +46,10 @@ type Example = [avro|
 type ExampleFromFile = [avroFile|adapter/avro/test/avro/example.avsc|]
 #else
 type ExampleFromFile = [avroFile|test/avro/example.avsc|]
+#endif
+
+#if __GHCIDE__
+avdl "ExampleProtocol" "ExampleService" "." "adapter/avro/test/avro/example.avdl"
+#else
+avdl "ExampleProtocol" "ExampleService" "." "test/avro/example.avdl"
 #endif

--- a/adapter/avro/test/avro/example.avdl
+++ b/adapter/avro/test/avro/example.avdl
@@ -1,0 +1,25 @@
+@namespace("example.seed.server.protocol.avro")
+protocol Service {
+  record Person {
+    string name;
+    int age;
+  }
+
+  error NotFoundError {
+    string message;
+  }
+
+  error DuplicatedPersonError {
+    string message;
+  }
+
+  record PeopleRequest {
+    string name;
+  }
+
+  record PeopleResponse {
+    union { Person, NotFoundError, DuplicatedPersonError } result;
+  }
+
+  example.seed.server.protocol.avro.PeopleResponse getPerson(example.seed.server.protocol.avro.PeopleRequest request);
+}


### PR DESCRIPTION
The generated code was failing to typecheck due to API changes in #198.

Added an example to check that code generated by the `avdl` function now compiles.