### PR TITLE
Add needed kind signatures

### DIFF
--- a/adapter/avro/src/Mu/Quasi/Avro.hs
+++ b/adapter/avro/src/Mu/Quasi/Avro.hs
@@ -1,4 +1,5 @@
 {-# language DataKinds         #-}
+{-# language KindSignatures    #-}
 {-# language LambdaCase        #-}
 {-# language NamedFieldPuns    #-}
 {-# language OverloadedStrings #-}
@@ -39,6 +40,7 @@ import           Data.Time
 import           Data.Time.Millis
 import           Data.UUID
 import qualified Data.Vector                as V
+import           GHC.TypeLits
 import           Language.Avro.Parser
 import qualified Language.Avro.Types        as A
 import           Language.Haskell.TH
@@ -93,7 +95,7 @@ avdlToDecls schemaName serviceName protocol
                             (S.toList $ A.messages protocol)) ] |]
        pure [schemaDec, serviceDec]
   where
-    pkgType Nothing = [t| 'Nothing |]
+    pkgType Nothing = [t| ('Nothing :: Maybe Symbol) |]
     pkgType (Just (A.Namespace p))
                     = [t| 'Just $(textToStrLit (T.intercalate "." p)) |]
 
@@ -182,7 +184,7 @@ avroMethodToType schemaName m
   where
     argToType :: A.Argument -> Q Type
     argToType (A.Argument (A.NamedType a) _)
-      = [t| 'ArgSingle 'Nothing ('SchemaRef $(conT schemaName) $(textToStrLit (A.baseName a))) |]
+      = [t| 'ArgSingle ('Nothing :: Maybe Symbol) ('SchemaRef $(conT schemaName) $(textToStrLit (A.baseName a))) |]
     argToType (A.Argument _ _)
       = fail "only named types may be used as arguments"
 

--- a/adapter/avro/src/Mu/Quasi/Avro/Example.hs
+++ b/adapter/avro/src/Mu/Quasi/Avro/Example.hs
@@ -1,5 +1,6 @@
 {-# language CPP             #-}
 {-# language DataKinds       #-}
+{-# language KindSignatures  #-}
 {-# language QuasiQuotes     #-}
 {-# language TemplateHaskell #-}
 

--- a/adapter/protobuf/src/Mu/Quasi/GRpc.hs
+++ b/adapter/protobuf/src/Mu/Quasi/GRpc.hs
@@ -75,7 +75,7 @@ pbServiceDeclToType pkg schema (P.Service nm _ methods)
           '[ 'Service $(textToStrLit nm)
                       $(typesToList <$> mapM (pbMethodToType schema) methods) ] |]
   where
-    pkgType Nothing  = [t| 'Nothing |]
+    pkgType Nothing  = [t| ('Nothing :: Maybe Symbol) |]
     pkgType (Just p) = [t| 'Just $(textToStrLit (T.intercalate "." p)) |]
 
 pbMethodToType :: Name -> P.Method -> Q Type


### PR DESCRIPTION
As part of the refactoring for 0.4, the type of names of arguments was generalized from being hardcoded to `Symbol` to being a parameter. This is required so that we can share the same data type as the type and term levels, since in the latter we need `Text` or `String` instead.

Unfortunately, this means that in some cases our quasi-quoters produce ambiguous types in those positions. Since they are supposed to always produce `Symbol`, I've added enough kind signatures to prevent the problem from happening.

Alas, now sometimes users have to enable the `KindSignatures` extension.