### PR TITLE
Add parameter to RpcInfo

### DIFF
--- a/core/rpc/src/Mu/Rpc.hs
+++ b/core/rpc/src/Mu/Rpc.hs
@@ -131,11 +131,12 @@ data Return serviceName tyRef where
 
 -- | Reflection
 
-data RpcInfo
+data RpcInfo i
   = NoRpcInfo
   | RpcInfo { packageInfo :: Package Text Text Text TyInfo
             , serviceInfo :: Service Text Text Text TyInfo
             , methodInfo  :: Method  Text Text Text TyInfo
+            , extraInfo   :: i
             }
 
 data TyInfo
@@ -144,16 +145,16 @@ data TyInfo
   | TyTy     Text
   deriving (Show, Eq)
 
-instance Show RpcInfo where
+instance Show (RpcInfo i) where
   show NoRpcInfo
     = "<no info>"
-  show (RpcInfo (Package Nothing _) (Service s _) (Method m _ _))
+  show (RpcInfo (Package Nothing _) (Service s _) (Method m _ _) _)
     = T.unpack (s <> ":" <> m)
-  show (RpcInfo (Package (Just p) _) (Service s _) (Method m _ _))
+  show (RpcInfo (Package (Just p) _) (Service s _) (Method m _ _) _)
     = T.unpack (p <> ":" <> s <> ":" <> m)
 
 class ReflectRpcInfo (p :: Package') (s :: Service') (m :: Method') where
-  reflectRpcInfo :: Proxy p -> Proxy s -> Proxy m -> RpcInfo
+  reflectRpcInfo :: Proxy p -> Proxy s -> Proxy m -> i -> RpcInfo i
 class ReflectService (s :: Service') where
   reflectService :: Proxy s -> Service Text Text Text TyInfo
 class ReflectMethod (m :: Method') where

--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -70,8 +70,8 @@ newtype HiRequest = HiRequest { number :: Int }
            , ToSchema   QuickstartSchema "HiRequest"
            , FromSchema QuickstartSchema "HiRequest" )
 
-quickstartServer :: forall m. (MonadServer m)
-                 => ServerT '[] QuickStartService m _
+quickstartServer :: forall m i. (MonadServer m)
+                 => ServerT '[] i QuickStartService m _
 quickstartServer
   -- = Server (sayHello :<|>: sayHi :<|>: sayManyHellos :<|>: H0)
   = singleService ( method @"SayHello" sayHello
@@ -110,7 +110,8 @@ type ApolloBookAuthor = '[
   , "Author" ':-> Integer
   ]
 
-apolloServer :: forall m. (MonadServer m) => ServerT ApolloBookAuthor ApolloService m _
+apolloServer :: forall m i. (MonadServer m)
+             => ServerT ApolloBookAuthor i ApolloService m _
 apolloServer
   = resolver
       ( object @"Author" ( field @"name"   authorName

--- a/examples/health-check/mu-example-health-check.cabal
+++ b/examples/health-check/mu-example-health-check.cabal
@@ -1,5 +1,5 @@
 name:          mu-example-health-check
-version:       0.3.0.0
+version:       0.4.0.0
 synopsis:
   Example health-check project from mu-scala (with protobuf) ported to mu-haskell
 
@@ -26,10 +26,10 @@ executable health-server
     , conduit
     , deferred-folds
     , mu-graphql
-    , mu-grpc-server  >=0.3.0
+    , mu-grpc-server  >=0.4.0
     , mu-prometheus
-    , mu-protobuf     >=0.3.0
-    , mu-rpc          >=0.3.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
     , stm
     , stm-conduit
@@ -49,8 +49,8 @@ executable health-client-tyapps
       base            >=4.12  && <5
     , conduit
     , mu-grpc-client  >=0.3.0
-    , mu-protobuf     >=0.3.0
-    , mu-rpc          >=0.3.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
     , text
 

--- a/examples/health-check/src/Server.hs
+++ b/examples/health-check/src/Server.hs
@@ -45,7 +45,7 @@ main = do
 type StatusMap = M.Map T.Text T.Text
 type StatusUpdates = TBMChan HealthStatusMsg
 
-server :: StatusMap -> StatusUpdates -> ServerIO HealthCheckService _
+server :: StatusMap -> StatusUpdates -> ServerIO info HealthCheckService _
 server m upd
   = wrapServer (\info h -> liftIO (print info) >> h) $
     singleService ( method @"setStatus"   $ setStatus_ m upd

--- a/examples/route-guide/mu-example-route-guide.cabal
+++ b/examples/route-guide/mu-example-route-guide.cabal
@@ -1,5 +1,5 @@
 name:          mu-example-route-guide
-version:       0.3.0.0
+version:       0.4.0.0
 synopsis:
   Example route-guide project from mu-scala ported to mu-haskell
 
@@ -26,9 +26,9 @@ executable route-guide-server
     , base            >=4.12  && <5
     , conduit
     , hashable
-    , mu-grpc-server  >=0.3.0
-    , mu-protobuf     >=0.3.0
-    , mu-rpc          >=0.3.0
+    , mu-grpc-server  >=0.4.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
     , stm
     , stm-chans

--- a/examples/route-guide/src/Server.hs
+++ b/examples/route-guide/src/Server.hs
@@ -69,7 +69,7 @@ calcDistance (Point lat1 lon1) (Point lat2 lon2)
 -- Server implementation
 -- https://github.com/higherkindness/mu/blob/master/modules/examples/routeguide/server/src/main/scala/handlers/RouteGuideServiceHandler.scala
 
-server :: Features -> TBMChan RouteNote -> ServerIO RouteGuideService _
+server :: Features -> TBMChan RouteNote -> ServerIO info RouteGuideService _
 server f m
   = singleService ( method @"GetFeature"   $ getFeature f
                   , method @"ListFeatures" $ listFeatures f

--- a/examples/seed/mu-example-seed.cabal
+++ b/examples/seed/mu-example-seed.cabal
@@ -35,9 +35,9 @@ executable seed-server
     , conduit
     , monad-logger
     , mu-graphql
-    , mu-grpc-server  >=0.3.0
-    , mu-protobuf     >=0.3.0
-    , mu-rpc          >=0.3.0
+    , mu-grpc-server  >=0.4.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
     , random
     , stm
@@ -53,10 +53,10 @@ executable seed-server-optics
       base            >=4.12  && <5
     , conduit
     , monad-logger
-    , mu-grpc-server  >=0.3.0
+    , mu-grpc-server  >=0.4.0
     , mu-optics       >=0.3.0
-    , mu-protobuf     >=0.3.0
-    , mu-rpc          >=0.3.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
     , random
     , stm

--- a/examples/seed/src/Main.hs
+++ b/examples/seed/src/Main.hs
@@ -85,7 +85,7 @@ main = do
 -- Server implementation
 -- https://github.com/higherkindness/mu/blob/master/modules/examples/seed/server/modules/process/src/main/scala/example/seed/server/process/ProtoPeopleServiceHandler.scala
 
-server :: (MonadServer m, MonadLogger m) => SingleServerT PeopleService m _
+server :: (MonadServer m, MonadLogger m) => SingleServerT info PeopleService m _
 server  = singleService
   ( method @"getPerson" getPerson
   , method @"getPersonStream" getPersonStream

--- a/examples/seed/src/Optics.hs
+++ b/examples/seed/src/Optics.hs
@@ -38,7 +38,7 @@ main = do
 -- Server implementation
 -- https://github.com/higherkindness/mu/blob/master/modules/examples/seed/server/modules/process/src/main/scala/example/seed/server/process/ProtoPeopleServiceHandler.scala
 
-server :: (MonadServer m, MonadLogger m) => SingleServerT PeopleService m _
+server :: (MonadServer m, MonadLogger m) => SingleServerT info PeopleService m _
 server = singleService
   ( method @"getPerson" getPerson
   , method @"getPersonStream" getPersonStream

--- a/examples/todolist/mu-example-todolist.cabal
+++ b/examples/todolist/mu-example-todolist.cabal
@@ -20,9 +20,9 @@ executable todolist-server
   other-modules:    Definition
   build-depends:
       base            >=4.12  && <5
-    , mu-grpc-server  >=0.3.0
-    , mu-protobuf     >=0.3.0
-    , mu-rpc          >=0.3.0
+    , mu-grpc-server  >=0.4.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
     , stm
     , text

--- a/examples/todolist/src/Server.hs
+++ b/examples/todolist/src/Server.hs
@@ -31,7 +31,7 @@ main = do
 type Id = TVar Int32
 type TodoList = TVar [TodoListMessage]
 
-server :: Id -> TodoList -> ServerIO TodoListService _
+server :: Id -> TodoList -> ServerIO info TodoListService _
 server i t
   = singleService ( method @"reset"    $ reset i t
                   , method @"insert"   $ insert i t

--- a/examples/with-persistent/mu-example-with-persistent.cabal
+++ b/examples/with-persistent/mu-example-with-persistent.cabal
@@ -24,10 +24,10 @@ executable persistent-server
       base                 >=4.12  && <5
     , conduit
     , monad-logger
-    , mu-grpc-server       >=0.3.0
+    , mu-grpc-server       >=0.4.0
     , mu-persistent        >=0.3.0
-    , mu-protobuf          >=0.3.0
-    , mu-rpc               >=0.3.0
+    , mu-protobuf          >=0.4.0
+    , mu-rpc               >=0.4.0
     , mu-schema            >=0.3.0
     , persistent
     , persistent-sqlite
@@ -42,8 +42,8 @@ executable persistent-client
     , conduit
     , mu-grpc-client       >=0.3.0
     , mu-persistent        >=0.3.0
-    , mu-protobuf          >=0.3.0
-    , mu-rpc               >=0.3.0
+    , mu-protobuf          >=0.4.0
+    , mu-rpc               >=0.4.0
     , mu-schema            >=0.3.0
     , persistent
     , persistent-sqlite
@@ -62,8 +62,8 @@ executable persistent-client-record
     , conduit
     , mu-grpc-client       >=0.3.0
     , mu-persistent        >=0.3.0
-    , mu-protobuf          >=0.3.0
-    , mu-rpc               >=0.3.0
+    , mu-protobuf          >=0.4.0
+    , mu-rpc               >=0.4.0
     , mu-schema            >=0.3.0
     , persistent
     , persistent-sqlite
@@ -83,8 +83,8 @@ executable persistent-client-optics
     , mu-grpc-client       >=0.3.0.0
     , mu-optics            >=0.3.0.0
     , mu-persistent        >=0.3.0
-    , mu-protobuf          >=0.3.0
-    , mu-rpc               >=0.3.0
+    , mu-protobuf          >=0.4.0
+    , mu-rpc               >=0.4.0
     , mu-schema            >=0.3.0
     , persistent
     , persistent-sqlite

--- a/examples/with-persistent/src/Server.hs
+++ b/examples/with-persistent/src/Server.hs
@@ -27,7 +27,7 @@ main = do
       runDb conn $ runMigration migrateAll
       liftIO $ runGRpcApp msgProtoBuf 1234 (server conn)
 
-server :: SqlBackend -> SingleServerT PersistentService ServerErrorIO _
+server :: SqlBackend -> SingleServerT info PersistentService ServerErrorIO _
 server p
   = singleService ( method @"getPerson" $ getPerson p
                   , method @"newPerson" $ newPerson p

--- a/graphql/exe/Main.hs
+++ b/graphql/exe/Main.hs
@@ -63,7 +63,8 @@ library
     , (3, "Michael Ende", [(4, "The Neverending Story"), (5, "Momo")])
     ]
 
-libraryServer :: forall m. (MonadServer m) => ServerT ServiceMapping ServiceDefinition m _
+libraryServer :: forall m i. (MonadServer m)
+              => ServerT ServiceMapping i ServiceDefinition m _
 libraryServer
   = resolver ( object @"Book"   ( field  @"id"      bookId
                                 , field  @"title"   bookTitle

--- a/graphql/src/Mu/GraphQL/Query/Definition.hs
+++ b/graphql/src/Mu/GraphQL/Query/Definition.hs
@@ -55,7 +55,8 @@ data OneMethodQuery (p :: Package snm mnm anm (TypeRef snm))
 data ChosenMethodQuery (p :: Package snm mnm anm (TypeRef snm))
                        (m :: Method snm mnm anm (TypeRef snm)) where
   ChosenMethodQuery
-    :: NP (ArgumentValue p) args
+    :: GQL.Field
+    -> NP (ArgumentValue p) args
     -> ReturnQuery p r
     -> ChosenMethodQuery p ('Method mname args r)
 

--- a/graphql/src/Mu/GraphQL/Server.hs
+++ b/graphql/src/Mu/GraphQL/Server.hs
@@ -43,6 +43,7 @@ import qualified Data.Text                        as T
 import           Data.Text.Encoding               (decodeUtf8)
 import qualified Data.Text.Lazy.Encoding          as T
 import           Language.GraphQL.Draft.Parser    (parseExecutableDoc)
+import qualified Language.GraphQL.Draft.Syntax    as GQL
 import           Mu.Adapter.Json                  ()
 import           Network.HTTP.Types.Header        (hContentType)
 import           Network.HTTP.Types.Method        (StdMethod (..), parseMethod)
@@ -71,7 +72,7 @@ instance A.FromJSON GraphQLInput where
 --   queries, but also mutations or subscriptions.
 graphQLApp ::
     ( GraphQLApp p qr mut sub ServerErrorIO chn hs )
-    => ServerT chn p ServerErrorIO hs
+    => ServerT chn GQL.Field p ServerErrorIO hs
     -> Proxy qr
     -> Proxy mut
     -> Proxy sub
@@ -83,7 +84,7 @@ graphQLApp = graphQLAppTrans id
 graphQLAppQuery ::
     forall qr p chn hs.
     ( GraphQLApp p ('Just qr) 'Nothing 'Nothing ServerErrorIO chn hs )
-    => ServerT chn p ServerErrorIO hs
+    => ServerT chn GQL.Field p ServerErrorIO hs
     -> Proxy qr
     -> Application
 graphQLAppQuery svr _
@@ -96,7 +97,7 @@ graphQLAppTransQuery ::
     forall qr m p chn hs.
     ( GraphQLApp p ('Just qr) 'Nothing 'Nothing m chn hs )
     => (forall a. m a -> ServerErrorIO a)
-    -> ServerT chn p m hs
+    -> ServerT chn GQL.Field p m hs
     -> Proxy qr
     -> Application
 graphQLAppTransQuery f svr _
@@ -108,7 +109,7 @@ graphQLAppTransQuery f svr _
 graphQLAppTrans ::
     ( GraphQLApp p qr mut sub m chn hs )
     => (forall a. m a -> ServerErrorIO a)
-    -> ServerT chn p m hs
+    -> ServerT chn GQL.Field p m hs
     -> Proxy qr
     -> Proxy mut
     -> Proxy sub
@@ -121,7 +122,7 @@ graphQLAppTrans f server q m s
 httpGraphQLAppTrans ::
     ( GraphQLApp p qr mut sub m chn hs )
     => (forall a. m a -> ServerErrorIO a)
-    -> ServerT chn p m hs
+    -> ServerT chn GQL.Field p m hs
     -> Proxy qr
     -> Proxy mut
     -> Proxy sub
@@ -164,7 +165,7 @@ httpGraphQLAppTrans f server q m s req res =
 wsGraphQLAppTrans
     :: ( GraphQLApp p qr mut sub m chn hs )
     => (forall a. m a -> ServerErrorIO a)
-    -> ServerT chn p m hs
+    -> ServerT chn GQL.Field p m hs
     -> Proxy qr
     -> Proxy mut
     -> Proxy sub
@@ -179,7 +180,7 @@ wsGraphQLAppTrans f server q m s conn
 runGraphQLAppSettings ::
   ( GraphQLApp p qr mut sub ServerErrorIO chn hs )
   => Settings
-  -> ServerT chn p ServerErrorIO hs
+  -> ServerT chn GQL.Field p ServerErrorIO hs
   -> Proxy qr
   -> Proxy mut
   -> Proxy sub
@@ -190,7 +191,7 @@ runGraphQLAppSettings st svr q m s = runSettings st (graphQLApp svr q m s)
 runGraphQLApp ::
   ( GraphQLApp p qr mut sub ServerErrorIO chn hs )
   => Port
-  -> ServerT chn p ServerErrorIO hs
+  -> ServerT chn GQL.Field p ServerErrorIO hs
   -> Proxy qr
   -> Proxy mut
   -> Proxy sub
@@ -202,7 +203,7 @@ runGraphQLAppTrans ::
   ( GraphQLApp p qr mut sub m chn hs )
   => Port
   -> (forall a. m a -> ServerErrorIO a)
-  -> ServerT chn p m hs
+  -> ServerT chn GQL.Field p m hs
   -> Proxy qr
   -> Proxy mut
   -> Proxy sub
@@ -213,7 +214,7 @@ runGraphQLAppTrans port f svr q m s = run port (graphQLAppTrans f svr q m s)
 runGraphQLAppQuery ::
   ( GraphQLApp p ('Just qr) 'Nothing 'Nothing ServerErrorIO chn hs )
   => Port
-  -> ServerT chn p ServerErrorIO hs
+  -> ServerT chn GQL.Field p ServerErrorIO hs
   -> Proxy qr
   -> IO ()
 runGraphQLAppQuery port svr q = run port (graphQLAppQuery svr q)

--- a/instrumentation/prometheus/src/Mu/Instrumentation/Prometheus.hs
+++ b/instrumentation/prometheus/src/Mu/Instrumentation/Prometheus.hs
@@ -41,15 +41,15 @@ initPrometheus prefix =
                                      defaultBuckets)
 
 prometheus :: (MonadBaseControl IO m, MonadMonitor m)
-           => MuMetrics -> ServerT chn p m topHs -> ServerT chn p m topHs
+           => MuMetrics -> ServerT chn info p m topHs -> ServerT chn info p m topHs
 prometheus m = wrapServer (prometheusMetrics m)
 
-prometheusMetrics :: forall m a. (MonadBaseControl IO m, MonadMonitor m)
-                  => MuMetrics -> RpcInfo -> m a -> m a
+prometheusMetrics :: forall m a info. (MonadBaseControl IO m, MonadMonitor m)
+                  => MuMetrics -> RpcInfo info -> m a -> m a
 prometheusMetrics metrics NoRpcInfo run = do
   incGauge (activeCalls metrics)
   run `finally` decGauge (activeCalls metrics)
-prometheusMetrics metrics (RpcInfo _pkg (Service sname _) (Method mname _ _)) run = do
+prometheusMetrics metrics (RpcInfo _pkg (Service sname _) (Method mname _ _) _) run = do
   incGauge (activeCalls metrics)
   withLabel (messagesReceived metrics) (sname, mname) incCounter
   ( do -- We are forced to use a MVar because 'withLabel' only allows IO ()


### PR DESCRIPTION
This PR adds an additional parameter to the `RpcInfo` data type which can be used by different protocols to add additional information about the request. In particular, we make GraphQL servers include the whole query as given by the user, including all information about selection, as requested by #190 

Fixes #190 @dandoh 