### PR TITLE
Add boundaries to all Cabal files 🚀

### DIFF
--- a/adapter/avro/mu-avro.cabal
+++ b/adapter/avro/mu-avro.cabal
@@ -28,24 +28,24 @@ library
     Mu.Quasi.Avro.Example
 
   build-depends:
-      aeson
-    , avro                  >=0.5.1
+      aeson                 >=1.5.2   && <1.6
+    , avro                  >=0.5.2   && <0.6
     , base                  >=4.12    && <5
-    , bytestring
-    , containers
-    , deepseq
-    , language-avro         >=0.1.3.1
+    , bytestring            >=0.10.10 && <0.11
+    , containers            >=0.6.2   && <0.7
+    , deepseq               >=1.4.4   && <1.5
+    , language-avro         >=0.1.3   && <0.2
     , mu-rpc                >=0.4.0
-    , mu-schema             >=0.3.0
-    , sop-core
-    , tagged
-    , template-haskell      >=2.12
-    , text
-    , time
-    , transformers
-    , unordered-containers
-    , uuid
-    , vector
+    , mu-schema             >=0.4.0
+    , sop-core              >=0.5.0   && <0.6
+    , tagged                >=0.8.6   && <0.9
+    , template-haskell      >=2.15.0  && <2.16
+    , text                  >=1.2.4   && <1.3
+    , time                  >=1.9.3   && <1.10
+    , transformers          >=0.5.6   && <0.6
+    , unordered-containers  >=0.2.11  && <0.3
+    , uuid                  >=1.3.13  && <1.4
+    , vector                >=0.12.1  && <0.13
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -55,10 +55,10 @@ executable test-avro
   main-is:          Avro.hs
   build-depends:
       avro        >=0.5
-    , base        >=4.12  && <5
-    , bytestring
-    , mu-avro     >=0.3.0
-    , mu-schema   >=0.3.0
+    , base        >=4.12    && <5
+    , bytestring  >=0.10.10 && <0.11
+    , mu-avro     >=0.4.0
+    , mu-schema   >=0.4.0
 
   hs-source-dirs:   test
   default-language: Haskell2010

--- a/adapter/avro/mu-avro.cabal
+++ b/adapter/avro/mu-avro.cabal
@@ -28,24 +28,24 @@ library
     Mu.Quasi.Avro.Example
 
   build-depends:
-      aeson                 >=1.5.2   && <1.6
-    , avro                  >=0.5.2   && <0.6
-    , base                  >=4.12    && <5
-    , bytestring            >=0.10.10 && <0.11
-    , containers            >=0.6.2   && <0.7
-    , deepseq               >=1.4.4   && <1.5
-    , language-avro         >=0.1.3   && <0.2
-    , mu-rpc                >=0.4.0
-    , mu-schema             >=0.4.0
-    , sop-core              >=0.5.0   && <0.6
-    , tagged                >=0.8.6   && <0.9
-    , template-haskell      >=2.15.0  && <2.16
-    , text                  >=1.2.4   && <1.3
-    , time                  >=1.9.3   && <1.10
-    , transformers          >=0.5.6   && <0.6
-    , unordered-containers  >=0.2.11  && <0.3
-    , uuid                  >=1.3.13  && <1.4
-    , vector                >=0.12.1  && <0.13
+      aeson                 >=1.4    && <2
+    , avro                  >=0.5.1  && <0.6
+    , base                  >=4.12   && <5
+    , bytestring            >=0.10   && <0.11
+    , containers            >=0.6    && <0.7
+    , deepseq               >=1.4    && <2
+    , language-avro         >=0.1.3  && <0.2
+    , mu-rpc                ==0.4.*
+    , mu-schema             ==0.3.*
+    , sop-core              >=0.5.0  && <0.6
+    , tagged                >=0.8.6  && <0.9
+    , template-haskell      >=2.14   && <2.16
+    , text                  >=1.2    && <2
+    , time                  >=1.9    && <2
+    , transformers          >=0.5    && <0.6
+    , unordered-containers  >=0.2    && <0.3
+    , uuid                  >=1.3    && <2
+    , vector                >=0.12   && <0.13
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -54,11 +54,11 @@ library
 executable test-avro
   main-is:          Avro.hs
   build-depends:
-      avro        >=0.5
-    , base        >=4.12    && <5
-    , bytestring  >=0.10.10 && <0.11
-    , mu-avro     >=0.4.0
-    , mu-schema   >=0.4.0
+      avro        >=0.5.1 && <0.6
+    , base        >=4.12  && <5
+    , bytestring  >=0.10  && <0.11
+    , mu-avro     ==0.4.*
+    , mu-schema   ==0.3.*
 
   hs-source-dirs:   test
   default-language: Haskell2010

--- a/adapter/kafka/mu-kafka.cabal
+++ b/adapter/kafka/mu-kafka.cabal
@@ -1,5 +1,5 @@
 name:               mu-kafka
-version:            0.4.0.0
+version:            0.3.0.0
 synopsis:           Utilities for interoperation between Mu and Kafka
 description:
   This package provides simple interoperation between Mu and Kafka using @hw-kafka-client@
@@ -29,14 +29,14 @@ library
   hs-source-dirs:   src
   default-language: Haskell2010
   build-depends:
-      avro              >=0.5.2   && <0.6
-    , base              >=4.7     && <5
-    , bytestring        >=0.10.10 && <0.11
-    , conduit           >=1.3.2   && <1.4
-    , hw-kafka-client   >=3.1.1   && <3.2
-    , hw-kafka-conduit  >=2.7.0   && <2.8
-    , mu-avro           >=0.4.0
-    , mu-schema         >=0.4.0
-    , resourcet         >=1.2.4   && <1.3
+      avro              >=0.5.1 && <0.6
+    , base              >=4.12  && <5
+    , bytestring        >=0.10  && <0.11
+    , conduit           >=1.3.2 && <2
+    , hw-kafka-client   >=3     && <4
+    , hw-kafka-conduit  >=2.7   && <3
+    , mu-avro           ==0.4.*
+    , mu-schema         ==0.3.*
+    , resourcet         >=1.2    && <2
 
   ghc-options:      -Wall

--- a/adapter/kafka/mu-kafka.cabal
+++ b/adapter/kafka/mu-kafka.cabal
@@ -1,5 +1,5 @@
 name:               mu-kafka
-version:            0.3.0.0
+version:            0.4.0.0
 synopsis:           Utilities for interoperation between Mu and Kafka
 description:
   This package provides simple interoperation between Mu and Kafka using @hw-kafka-client@
@@ -29,14 +29,14 @@ library
   hs-source-dirs:   src
   default-language: Haskell2010
   build-depends:
-      avro              >=0.5
-    , base              >=4.7   && <5
-    , bytestring
-    , conduit
-    , hw-kafka-client
-    , hw-kafka-conduit
-    , mu-avro           >=0.3.0
-    , mu-schema         >=0.3.0
-    , resourcet
+      avro              >=0.5.2   && <0.6
+    , base              >=4.7     && <5
+    , bytestring        >=0.10.10 && <0.11
+    , conduit           >=1.3.2   && <1.4
+    , hw-kafka-client   >=3.1.1   && <3.2
+    , hw-kafka-conduit  >=2.7.0   && <2.8
+    , mu-avro           >=0.4.0
+    , mu-schema         >=0.4.0
+    , resourcet         >=1.2.4   && <1.3
 
   ghc-options:      -Wall

--- a/adapter/persistent/mu-persistent.cabal
+++ b/adapter/persistent/mu-persistent.cabal
@@ -1,5 +1,5 @@
 name:               mu-persistent
-version:            0.4.0.0
+version:            0.3.0.0
 synopsis:           Utilities for interoperation between Mu and Persistent
 description:
   Please see the <https://github.com/higherkindness/mu-haskell/persistent#readme readme file>.
@@ -27,11 +27,11 @@ library
   hs-source-dirs:   src
   default-language: Haskell2010
   build-depends:
-      base          >=4.7    && <5
-    , monad-logger  >=0.3.32 && <0.4
-    , mu-schema     >=0.4
-    , persistent    >=2.10.5 && <2.11
-    , resourcet     >=1.2.4  && <1.3
-    , transformers  >=0.5.6  && <0.6
+      base          >=4.12 && <5
+    , monad-logger  >=0.3  && <0.4
+    , mu-schema     ==0.3.*
+    , persistent    >=2.10 && <3
+    , resourcet     >=1.2  && <2
+    , transformers  >=0.5  && <0.6
 
   ghc-options:      -Wall

--- a/adapter/persistent/mu-persistent.cabal
+++ b/adapter/persistent/mu-persistent.cabal
@@ -1,5 +1,5 @@
 name:               mu-persistent
-version:            0.3.0.0
+version:            0.4.0.0
 synopsis:           Utilities for interoperation between Mu and Persistent
 description:
   Please see the <https://github.com/higherkindness/mu-haskell/persistent#readme readme file>.
@@ -27,11 +27,11 @@ library
   hs-source-dirs:   src
   default-language: Haskell2010
   build-depends:
-      base          >=4.7   && <5
-    , monad-logger
-    , mu-schema     >=0.3.0
-    , persistent
-    , resourcet
-    , transformers
+      base          >=4.7    && <5
+    , monad-logger  >=0.3.32 && <0.4
+    , mu-schema     >=0.4
+    , persistent    >=2.10.5 && <2.11
+    , resourcet     >=1.2.4  && <1.3
+    , transformers  >=0.5.6  && <0.6
 
   ghc-options:      -Wall

--- a/adapter/protobuf/mu-protobuf.cabal
+++ b/adapter/protobuf/mu-protobuf.cabal
@@ -32,18 +32,18 @@ library
 
   build-depends:
       base                    >=4.12  && <5
-    , bytestring
-    , compendium-client       >=0.2.0
-    , http-client
-    , http2-grpc-proto3-wire
-    , language-protobuf
-    , mu-rpc                  >=0.4.0
-    , mu-schema               >=0.3.0
-    , proto3-wire
-    , servant-client-core
-    , sop-core
-    , template-haskell        >=2.12
-    , text
+    , bytestring              >=0.10  && <0.11
+    , compendium-client       ==0.2.*
+    , http-client             >=0.6   && <0.7
+    , http2-grpc-proto3-wire  >=0.1   && <0.2
+    , language-protobuf       >=1.0.1 && <2
+    , mu-rpc                  ==0.4.*
+    , mu-schema               ==0.3.*
+    , proto3-wire             >=1.1   && < 2
+    , servant-client-core     >=0.16  && <0.17
+    , sop-core                >=0.5   && <0.6
+    , template-haskell        >=2.14  && <2.16
+    , text                    >=1.2   && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/cabal.project
+++ b/cabal.project
@@ -22,4 +22,4 @@ packages: compendium-client/
 source-repository-package
     type: git
     location: https://github.com/hasura/graphql-parser-hs.git
-    tag: ba2379640248ce67cdfe700cbb79acd91c644bdb
+    tag: f4a093981ca5626982a17c2bfaad047cc0834a81

--- a/compendium-client/compendium-client.cabal
+++ b/compendium-client/compendium-client.cabal
@@ -1,5 +1,5 @@
 name:          compendium-client
-version:       0.3.0.0
+version:       0.2.0.0
 synopsis:      Client for the Compendium schema server
 description:
   Client for the <https://github.com/higherkindness/compendium Compendium> schema server
@@ -22,14 +22,14 @@ source-repository head
 library
   exposed-modules:  Compendium.Client
   build-depends:
-      aeson              >=1.4.7 && <1.5
+      aeson              >=1.4   && <2
     , base               >=4.12  && <5
     , http-client        >=0.6.4 && <0.7
     , language-protobuf  >=1.0.1 && <1.1
-    , megaparsec         >=8.0.0 && <8.1
-    , servant            >=0.17  && <0.18
-    , servant-client     >=0.17  && <0.18
-    , text               >=1.2.4 && <1.3
+    , megaparsec         >=8     && <9
+    , servant            >=0.16  && <0.17
+    , servant-client     >=0.16  && <0.17
+    , text               >=1.2   && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/compendium-client/compendium-client.cabal
+++ b/compendium-client/compendium-client.cabal
@@ -1,5 +1,5 @@
 name:          compendium-client
-version:       0.2.0.0
+version:       0.3.0.0
 synopsis:      Client for the Compendium schema server
 description:
   Client for the <https://github.com/higherkindness/compendium Compendium> schema server
@@ -22,14 +22,14 @@ source-repository head
 library
   exposed-modules:  Compendium.Client
   build-depends:
-      aeson
-    , base               >=4.12 && <5
-    , http-client
-    , language-protobuf
-    , megaparsec
-    , servant
-    , servant-client
-    , text
+      aeson              >=1.4.7 && <1.5
+    , base               >=4.12  && <5
+    , http-client        >=0.6.4 && <0.7
+    , language-protobuf  >=1.0.1 && <1.1
+    , megaparsec         >=8.0.0 && <8.1
+    , servant            >=0.17  && <0.18
+    , servant-client     >=0.17  && <0.18
+    , text               >=1.2.4 && <1.3
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/core/optics/mu-optics.cabal
+++ b/core/optics/mu-optics.cabal
@@ -1,5 +1,5 @@
 name:          mu-optics
-version:       0.4.0.0
+version:       0.3.0.0
 synopsis:      Optics for @mu-schema@ terms
 description:
   With @mu-schema@ you can describe schemas using type-level constructs, and derive serializers from those. This package provides convenient access using @optics@.
@@ -22,11 +22,11 @@ source-repository head
 library
   exposed-modules:  Mu.Schema.Optics
   build-depends:
-      base         >=4.12  && <5
-    , containers   >=0.6.2 && <0.7
-    , mu-schema    >=0.4
-    , optics-core  >=0.3   && <0.4
-    , sop-core     >=0.5.0 && <0.6
+      base         >=4.12 && <5
+    , containers   >=0.6  && <0.7
+    , mu-schema    ==0.3.*
+    , optics-core  >=0.2  && <0.3
+    , sop-core     >=0.5  && <0.6
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/core/optics/mu-optics.cabal
+++ b/core/optics/mu-optics.cabal
@@ -1,5 +1,5 @@
 name:          mu-optics
-version:       0.3.0.0
+version:       0.4.0.0
 synopsis:      Optics for @mu-schema@ terms
 description:
   With @mu-schema@ you can describe schemas using type-level constructs, and derive serializers from those. This package provides convenient access using @optics@.
@@ -23,10 +23,10 @@ library
   exposed-modules:  Mu.Schema.Optics
   build-depends:
       base         >=4.12  && <5
-    , containers
-    , mu-schema    >=0.3.0
-    , optics-core
-    , sop-core
+    , containers   >=0.6.2 && <0.7
+    , mu-schema    >=0.4
+    , optics-core  >=0.3   && <0.4
+    , sop-core     >=0.5.0 && <0.6
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/core/rpc/mu-rpc.cabal
+++ b/core/rpc/mu-rpc.cabal
@@ -28,13 +28,13 @@ library
     Mu.Server
 
   build-depends:
-      base              >=4.12  && <5
-    , conduit
-    , mtl
-    , mu-schema         >=0.3.0
-    , sop-core
-    , template-haskell
-    , text
+      base              >=4.12   && <5
+    , conduit           >=1.3.2  && <1.4
+    , mtl               >=2.2.2  && <2.3
+    , mu-schema         >=0.4.0
+    , sop-core          >=0.5.0  && <0.6
+    , template-haskell  >=2.15.0 && <2.16
+    , text              >=1.2.4  && <1.3
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/core/rpc/mu-rpc.cabal
+++ b/core/rpc/mu-rpc.cabal
@@ -28,13 +28,13 @@ library
     Mu.Server
 
   build-depends:
-      base              >=4.12   && <5
-    , conduit           >=1.3.2  && <1.4
-    , mtl               >=2.2.2  && <2.3
-    , mu-schema         >=0.4.0
-    , sop-core          >=0.5.0  && <0.6
-    , template-haskell  >=2.15.0 && <2.16
-    , text              >=1.2.4  && <1.3
+      base              >=4.12  && <5
+    , conduit           >=1.3.2 && <1.4
+    , mtl               >=2.2   && <2.3
+    , mu-schema         ==0.3.*
+    , sop-core          >=0.5   && <0.6
+    , template-haskell  >=2.14  && <2.16
+    , text              >=1.2   && <1.3
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/core/schema/mu-schema.cabal
+++ b/core/schema/mu-schema.cabal
@@ -1,5 +1,5 @@
 name:               mu-schema
-version:            0.3.0.0
+version:            0.4.0.0
 synopsis:           Format-independent schemas for serialization
 description:
   With @mu-schema@ you can describe schemas using type-level constructs, and derive serializers from those. See @mu-avro@, @mu-protobuf@ for the actual adapters.
@@ -38,16 +38,16 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-      aeson
-    , base                  >=4.12 && <5
-    , bytestring
-    , containers
-    , sop-core
-    , template-haskell      >=2.12
-    , text
-    , th-abstraction
-    , unordered-containers
-    , vector
+      aeson                 >=1.5.2   && <1.6
+    , base                  >=4.12    && <5
+    , bytestring            >=0.10.10 && <0.11
+    , containers            >=0.6.2   && <0.7
+    , sop-core              >=0.5.0   && <0.6
+    , template-haskell      >=2.15.0  && <2.16
+    , text                  >=1.2.4   && <1.3
+    , th-abstraction        >=0.3.2   && <0.4
+    , unordered-containers  >=0.2.11  && <0.3
+    , vector                >=0.12.1  && <0.13
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/core/schema/mu-schema.cabal
+++ b/core/schema/mu-schema.cabal
@@ -1,5 +1,5 @@
 name:               mu-schema
-version:            0.4.0.0
+version:            0.3.0.0
 synopsis:           Format-independent schemas for serialization
 description:
   With @mu-schema@ you can describe schemas using type-level constructs, and derive serializers from those. See @mu-avro@, @mu-protobuf@ for the actual adapters.
@@ -38,16 +38,16 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:
-      aeson                 >=1.5.2   && <1.6
-    , base                  >=4.12    && <5
-    , bytestring            >=0.10.10 && <0.11
-    , containers            >=0.6.2   && <0.7
-    , sop-core              >=0.5.0   && <0.6
-    , template-haskell      >=2.15.0  && <2.16
-    , text                  >=1.2.4   && <1.3
-    , th-abstraction        >=0.3.2   && <0.4
-    , unordered-containers  >=0.2.11  && <0.3
-    , vector                >=0.12.1  && <0.13
+      aeson                 >=1.4   && <2
+    , base                  >=4.12  && <5
+    , bytestring            >=0.10  && <0.11
+    , containers            >=0.6   && <0.7
+    , sop-core              >=0.5   && <0.6
+    , template-haskell      >=2.14  && <2.16
+    , text                  >=1.2   && <2
+    , th-abstraction        >=0.3.2 && <0.4
+    , unordered-containers  >=0.2   && <0.3
+    , vector                >=0.12  && <0.13
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 let
-  haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/6cf92c4.tar.gz) {};
+  haskellNix = import (builtins.fetchTarball https://github.com/input-output-hk/haskell.nix/archive/9d491b5.tar.gz) {};
   nixpkgsSrc = haskellNix.sources.nixpkgs-2003;
   nixpkgsArgs = haskellNix.nixpkgsArgs;
 in

--- a/examples/health-check/mu-example-health-check.cabal
+++ b/examples/health-check/mu-example-health-check.cabal
@@ -21,22 +21,22 @@ executable health-server
   main-is:          Server.hs
   other-modules:    Definition
   build-depends:
-      async
+      async           >=2.2   && <3
     , base            >=4.12  && <5
-    , conduit
-    , deferred-folds
-    , mu-graphql
+    , conduit         >=1.3.2 && <2
+    , deferred-folds  >=0.9   && <0.10
+    , mu-graphql      >=0.4.0
     , mu-grpc-server  >=0.4.0
-    , mu-prometheus
+    , mu-prometheus   >=0.4.0
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
-    , stm
-    , stm-conduit
-    , stm-containers
-    , text
-    , wai
-    , warp
+    , stm             >=2.5   && <3
+    , stm-conduit     >=4     && <5
+    , stm-containers  >=1.1   && <2
+    , text            >=1.2   && <2
+    , wai             >=3.2   && <4
+    , warp            >=3.3   && <4
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -47,12 +47,12 @@ executable health-client-tyapps
   other-modules:    Definition
   build-depends:
       base            >=4.12  && <5
-    , conduit
-    , mu-grpc-client  >=0.3.0
+    , conduit         >=1.3.2 && <2
+    , mu-grpc-client  >=0.4.0
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
-    , text
+    , text            >=1.2   && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -63,12 +63,12 @@ executable health-client-record
   other-modules:    Definition
   build-depends:
       base            >=4.12  && <5
-    , conduit
-    , mu-grpc-client  >=0.3.0
-    , mu-protobuf     >=0.3.0
-    , mu-rpc          >=0.3.0
+    , conduit         >=1.3.2 && <2
+    , mu-grpc-client  >=0.4.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
-    , text
+    , text            >=1.2   && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/examples/route-guide/mu-example-route-guide.cabal
+++ b/examples/route-guide/mu-example-route-guide.cabal
@@ -21,20 +21,20 @@ executable route-guide-server
   main-is:          Server.hs
   other-modules:    Definition
   build-depends:
-      AC-Angle
-    , async
+      AC-Angle        >=1     && <2
+    , async           >=2.2   && <3
     , base            >=4.12  && <5
-    , conduit
-    , hashable
+    , conduit         >=1.3.2 && <2
+    , hashable        >=1.3   && <2
     , mu-grpc-server  >=0.4.0
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
-    , stm
-    , stm-chans
-    , text
-    , time
-    , transformers
+    , stm             >=2.5   && <3
+    , stm-chans       >=3     && <4
+    , text            >=1.2   && <2
+    , time            >=1.9   && <2
+    , transformers    >=0.5   && <0.6
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/examples/seed/mu-example-seed.cabal
+++ b/examples/seed/mu-example-seed.cabal
@@ -30,19 +30,19 @@ executable seed-server
   other-modules:    Schema
   default-language: Haskell2010
   build-depends:
-      async
+      async           >=2.2   && <3
     , base            >=4.12  && <5
-    , conduit
-    , monad-logger
-    , mu-graphql
+    , conduit         >=1.3.2 && <2
+    , monad-logger    >=0.3   && <0.4
+    , mu-graphql      >=0.4.0
     , mu-grpc-server  >=0.4.0
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
-    , random
-    , stm
-    , text
-    , wai
+    , random          >=1.1   && <2
+    , stm             >=2.5   && <3
+    , text            >=1.2   && <2
+    , wai             >=3.2   && <4
 
 executable seed-server-optics
   hs-source-dirs:   src
@@ -51,15 +51,15 @@ executable seed-server-optics
   default-language: Haskell2010
   build-depends:
       base            >=4.12  && <5
-    , conduit
-    , monad-logger
+    , conduit         >=1.3.2 && <2
+    , monad-logger    >=0.3   && <0.4
     , mu-grpc-server  >=0.4.0
     , mu-optics       >=0.3.0
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
-    , random
-    , stm
-    , text
+    , random          >=1.1   && <2
+    , stm             >=2.5   && <3
+    , text            >=1.2   && <2
 
   ghc-options:      -Wall -fprint-potential-instances

--- a/examples/todolist/mu-example-todolist.cabal
+++ b/examples/todolist/mu-example-todolist.cabal
@@ -24,9 +24,9 @@ executable todolist-server
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
-    , stm
-    , text
-    , transformers
+    , stm             >=2.5   && <3
+    , text            >=1.2   && <2
+    , transformers    >=0.5   && <0.6
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/examples/with-persistent/mu-example-with-persistent.cabal
+++ b/examples/with-persistent/mu-example-with-persistent.cabal
@@ -22,33 +22,33 @@ executable persistent-server
   default-language: Haskell2010
   build-depends:
       base                 >=4.12  && <5
-    , conduit
-    , monad-logger
-    , mu-grpc-server       >=0.4.0
-    , mu-persistent        >=0.3.0
-    , mu-protobuf          >=0.4.0
-    , mu-rpc               >=0.4.0
-    , mu-schema            >=0.3.0
-    , persistent
-    , persistent-sqlite
-    , persistent-template
-    , text
+    , conduit              >=1.3.2 && <2
+    , monad-logger         >=0.3   && <0.4
+    , mu-grpc-server       >=0.4
+    , mu-persistent        >=0.3
+    , mu-protobuf          >=0.4
+    , mu-rpc               >=0.4
+    , mu-schema            >=0.3
+    , persistent           >=2.10  && <3
+    , persistent-sqlite    >=2.10  && <3
+    , persistent-template  >=2.8   && <3
+    , text                 >=1.2   && <2
 
 executable persistent-client
   main-is:          Client.hs
   other-modules:    Schema
   build-depends:
       base                 >=4.12  && <5
-    , conduit
+    , conduit              >=1.3.2 && <2
     , mu-grpc-client       >=0.3.0
     , mu-persistent        >=0.3.0
     , mu-protobuf          >=0.4.0
     , mu-rpc               >=0.4.0
     , mu-schema            >=0.3.0
-    , persistent
-    , persistent-sqlite
-    , persistent-template
-    , text
+    , persistent           >=2.10  && <3
+    , persistent-sqlite    >=2.10  && <3
+    , persistent-template  >=2.8   && <3
+    , text                 >=1.2   && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -59,16 +59,16 @@ executable persistent-client-record
   other-modules:    Schema
   build-depends:
       base                 >=4.12  && <5
-    , conduit
+    , conduit              >=1.3.2 && <2
     , mu-grpc-client       >=0.3.0
     , mu-persistent        >=0.3.0
     , mu-protobuf          >=0.4.0
     , mu-rpc               >=0.4.0
     , mu-schema            >=0.3.0
-    , persistent
-    , persistent-sqlite
-    , persistent-template
-    , text
+    , persistent           >=2.10  && <3
+    , persistent-sqlite    >=2.10  && <3
+    , persistent-template  >=2.8   && <3
+    , text                 >=1.2   && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -78,18 +78,18 @@ executable persistent-client-optics
   main-is:          ClientOptics.hs
   other-modules:    Schema
   build-depends:
-      base                 >=4.12    && <5
-    , conduit
+      base                 >=4.12  && <5
+    , conduit              >=1.3.2 && <2
     , mu-grpc-client       >=0.3.0.0
     , mu-optics            >=0.3.0.0
     , mu-persistent        >=0.3.0
     , mu-protobuf          >=0.4.0
     , mu-rpc               >=0.4.0
     , mu-schema            >=0.3.0
-    , persistent
-    , persistent-sqlite
-    , persistent-template
-    , text
+    , persistent           >=2.10  && <3
+    , persistent-sqlite    >=2.10  && <3
+    , persistent-template  >=2.8   && <3
+    , text                 >=1.2   && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/graphql/mu-graphql.cabal
+++ b/graphql/mu-graphql.cabal
@@ -29,34 +29,34 @@ library
     Mu.GraphQL.Subscription.Protocol
 
   build-depends:
-      aeson                 >=1.5.2   && <1.6
-    , async                 >=2.2.2   && <2.3
-    , attoparsec            >=0.13.2  && <0.14
-    , base                  >=4.12    && <5
-    , bytestring            >=0.10.10 && <0.11
-    , conduit               >=1.3.2   && <1.4
+      aeson                 >=1.4   && <2
+    , async                 >=2.2   && <3
+    , attoparsec            >=0.13  && <0.14
+    , base                  >=4.12  && <5
+    , bytestring            >=0.10  && <0.11
+    , conduit               >=1.3.2 && <2
     , graphql-parser
-    , http-types            >=0.12.3  && <0.13
-    , list-t                >=1.0.4   && <1.1
-    , mtl                   >=2.2.2   && <2.3
-    , mu-rpc                >=0.4.0
-    , mu-schema             >=0.4.0
-    , parsers               >=0.12.10 && <0.13
-    , scientific            >=0.3.6   && <0.4
-    , sop-core              >=0.5.0   && <0.6
-    , stm                   >=2.5.0   && <2.6
-    , stm-chans             >=3.0.0   && <3.1
-    , stm-conduit           >=4.0.1   && <4.1
-    , stm-containers        >=1.1.0   && <1.2
-    , template-haskell      >=2.15.0  && <2.16
-    , text                  >=1.2.4   && <1.3
-    , unordered-containers  >=0.2.11  && <0.3
-    , uuid                  >=1.3.13  && <1.4
-    , wai                   >=3.2.2   && <3.3
-    , wai-websockets        >=3.0.1   && <3.1
-    , warp                  >=3.3.13  && <3.4
-    , warp-tls              >=3.3.0   && <3.4
-    , websockets            >=0.12.7  && <0.13
+    , http-types            >=0.12  && <0.13
+    , list-t                >=1.0   && <2
+    , mtl                   >=2.2   && <2.3
+    , mu-rpc                ==0.4.*
+    , mu-schema             ==0.3.*
+    , parsers               >=0.12  && <0.13
+    , scientific            >=0.3   && <0.4
+    , sop-core              >=0.5   && <0.6
+    , stm                   >=2.5   && <3
+    , stm-chans             >=3     && <4
+    , stm-conduit           >=4     && <5
+    , stm-containers        >=1.1   && <2
+    , template-haskell      >=2.14  && <2.16
+    , text                  >=1.2   && <1.3
+    , unordered-containers  >=0.2   && <0.3
+    , uuid                  >=1.3   && <2
+    , wai                   >=3.2   && <4
+    , wai-websockets        >=3     && <4
+    , warp                  >=3.3   && <4
+    , warp-tls              >=3.2   && <4
+    , websockets            >=0.12  && <0.13
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -68,12 +68,12 @@ executable library-graphql
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-      base        >=4.12   && <5
-    , conduit     >=1.3.2  && <1.4
-    , mu-graphql  >=0.4
-    , mu-rpc      >=0.4
-    , mu-schema   >=0.4
-    , regex-tdfa  >=1.3.1  && <1.4
-    , text        >=1.2.4  && <1.3
-    , wai-extra   >=3.0.29 && <3.1
-    , warp        >=3.3.13 && <3.4
+      base        >=4.12  && <5
+    , conduit     >=1.3.2 && <1.4
+    , mu-graphql  ==0.4.*
+    , mu-rpc      ==0.4.*
+    , mu-schema   ==0.3.*
+    , regex-tdfa  >=1.3   && <2
+    , text        >=1.2   && <2
+    , wai-extra   >=3     && <4
+    , warp        >=3.3   && <4

--- a/graphql/mu-graphql.cabal
+++ b/graphql/mu-graphql.cabal
@@ -28,36 +28,35 @@ library
     Mu.GraphQL.Query.Run
     Mu.GraphQL.Subscription.Protocol
 
-  -- other-extensions:
   build-depends:
-      aeson
-    , async
-    , attoparsec
-    , base                  >=4.12 && <5
-    , bytestring
-    , conduit
+      aeson                 >=1.5.2   && <1.6
+    , async                 >=2.2.2   && <2.3
+    , attoparsec            >=0.13.2  && <0.14
+    , base                  >=4.12    && <5
+    , bytestring            >=0.10.10 && <0.11
+    , conduit               >=1.3.2   && <1.4
     , graphql-parser
-    , http-types
-    , list-t
-    , mtl
-    , mu-rpc                >=0.4
-    , mu-schema             >=0.3
-    , parsers
-    , scientific
-    , sop-core
-    , stm
-    , stm-chans
-    , stm-conduit
-    , stm-containers
-    , template-haskell
-    , text
-    , unordered-containers
-    , uuid
-    , wai
-    , wai-websockets
-    , warp
-    , warp-tls
-    , websockets
+    , http-types            >=0.12.3  && <0.13
+    , list-t                >=1.0.4   && <1.1
+    , mtl                   >=2.2.2   && <2.3
+    , mu-rpc                >=0.4.0
+    , mu-schema             >=0.4.0
+    , parsers               >=0.12.10 && <0.13
+    , scientific            >=0.3.6   && <0.4
+    , sop-core              >=0.5.0   && <0.6
+    , stm                   >=2.5.0   && <2.6
+    , stm-chans             >=3.0.0   && <3.1
+    , stm-conduit           >=4.0.1   && <4.1
+    , stm-containers        >=1.1.0   && <1.2
+    , template-haskell      >=2.15.0  && <2.16
+    , text                  >=1.2.4   && <1.3
+    , unordered-containers  >=0.2.11  && <0.3
+    , uuid                  >=1.3.13  && <1.4
+    , wai                   >=3.2.2   && <3.3
+    , wai-websockets        >=3.0.1   && <3.1
+    , warp                  >=3.3.13  && <3.4
+    , warp-tls              >=3.3.0   && <3.4
+    , websockets            >=0.12.7  && <0.13
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -69,12 +68,12 @@ executable library-graphql
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-      base        >=4.12    && <5
-    , conduit
-    , mu-graphql
-    , mu-rpc
-    , mu-schema
-    , regex-tdfa  >=1.3.1.0
-    , text
-    , wai-extra
-    , warp
+      base        >=4.12   && <5
+    , conduit     >=1.3.2  && <1.4
+    , mu-graphql  >=0.4
+    , mu-rpc      >=0.4
+    , mu-schema   >=0.4
+    , regex-tdfa  >=1.3.1  && <1.4
+    , text        >=1.2.4  && <1.3
+    , wai-extra   >=3.0.29 && <3.1
+    , warp        >=3.3.13 && <3.4

--- a/grpc/client/mu-grpc-client.cabal
+++ b/grpc/client/mu-grpc-client.cabal
@@ -29,28 +29,28 @@ library
 
   other-modules:    Mu.GRpc.Client.Internal
   build-depends:
-      async
-    , avro               >=0.5
+      async              >=2.2   && < 3
+    , avro               >=0.5.1 && <0.6
     , base               >=4.12  && <5
-    , bytestring
-    , conduit
-    , http2
-    , http2-client
-    , http2-client-grpc
-    , http2-grpc-types
-    , mu-grpc-common     >=0.4.0
-    , mu-optics          >=0.4.0
-    , mu-protobuf        >=0.4.0
-    , mu-rpc             >=0.4.0
-    , mu-schema          >=0.4.0
-    , optics-core
-    , sop-core
-    , stm
-    , stm-chans
-    , stm-conduit
-    , template-haskell   >=2.12
-    , text
-    , th-abstraction
+    , bytestring         >=0.10  && <0.11
+    , conduit            >=1.3.2 && <2
+    , http2              >=1.6   && <2.1
+    , http2-client       >=0.9   && <1
+    , http2-client-grpc  >=0.8   && <0.9
+    , http2-grpc-types   >=0.5   && <0.6
+    , mu-grpc-common     ==0.4.*
+    , mu-optics          ==0.3.*
+    , mu-protobuf        ==0.4.*
+    , mu-rpc             ==0.4.*
+    , mu-schema          ==0.3.*
+    , optics-core        >=0.2   && <0.3
+    , sop-core           >=0.5   && <0.6
+    , stm                >=2.5   && <3
+    , stm-chans          >=3     && <4
+    , stm-conduit        >=4     && <5
+    , template-haskell   >=2.14  && <2.16
+    , text               >=1.2   && <2
+    , th-abstraction     >=0.3.2 && <0.4
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/grpc/client/mu-grpc-client.cabal
+++ b/grpc/client/mu-grpc-client.cabal
@@ -39,10 +39,10 @@ library
     , http2-client-grpc
     , http2-grpc-types
     , mu-grpc-common     >=0.4.0
-    , mu-optics          >=0.3.0
+    , mu-optics          >=0.4.0
     , mu-protobuf        >=0.4.0
     , mu-rpc             >=0.4.0
-    , mu-schema          >=0.3.0
+    , mu-schema          >=0.4.0
     , optics-core
     , sop-core
     , stm

--- a/grpc/common/mu-grpc-common.cabal
+++ b/grpc/common/mu-grpc-common.cabal
@@ -25,16 +25,16 @@ library
     Mu.GRpc.Bridge
 
   build-depends:
-      avro                    >=0.5
+      avro                    >=0.5.1 && <0.6
     , base                    >=4.12  && <5
-    , binary
-    , bytestring
-    , http2-grpc-proto3-wire
-    , http2-grpc-types
-    , mu-avro                 >=0.4.0
-    , mu-protobuf             >=0.4.0
-    , mu-rpc                  >=0.4.0
-    , mu-schema               >=0.4.0
+    , binary                  >=0.8   && <0.9
+    , bytestring              >=0.10  && <0.11
+    , http2-grpc-proto3-wire  >=0.1   && <0.2
+    , http2-grpc-types        >=0.5   && <0.6
+    , mu-avro                 ==0.4.*
+    , mu-protobuf             ==0.4.*
+    , mu-rpc                  ==0.4.*
+    , mu-schema               ==0.3.*
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/grpc/common/mu-grpc-common.cabal
+++ b/grpc/common/mu-grpc-common.cabal
@@ -34,7 +34,7 @@ library
     , mu-avro                 >=0.4.0
     , mu-protobuf             >=0.4.0
     , mu-rpc                  >=0.4.0
-    , mu-schema               >=0.3.0
+    , mu-schema               >=0.4.0
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/grpc/server/mu-grpc-server.cabal
+++ b/grpc/server/mu-grpc-server.cabal
@@ -23,25 +23,25 @@ source-repository head
 library
   exposed-modules:  Mu.GRpc.Server
   build-depends:
-      async
-    , avro              >=0.5
+      async             >=2.2     && < 3
+    , avro              >=0.5.1   && <0.6
     , base              >=4.12    && <5
-    , binary
-    , bytestring
-    , conduit
-    , http2-grpc-types
-    , mtl
-    , mu-grpc-common    >=0.4.0
-    , mu-protobuf       >=0.4.0
-    , mu-rpc            >=0.4.0
-    , mu-schema         >=0.4.0
-    , sop-core
-    , stm
-    , stm-conduit
-    , wai
-    , warp
-    , warp-grpc         >=0.4.0.1
-    , warp-tls
+    , binary            >=0.8     && <0.9
+    , bytestring        >=0.10    && <0.11
+    , conduit           >=1.3.2   && <2
+    , http2-grpc-types  >=0.5     && <0.6
+    , mtl               >=2.2     && <3
+    , mu-grpc-common    ==0.4.*
+    , mu-protobuf       ==0.4.*
+    , mu-rpc            ==0.4.*
+    , mu-schema         ==0.3.*
+    , sop-core          >=0.5     && <0.6
+    , stm               >=2.5     && <3
+    , stm-conduit       >=4       && <5
+    , wai               >=3.2     && <4
+    , warp              >=3.3     && <4
+    , warp-grpc         >=0.4.0.1 && <0.5
+    , warp-tls          >=3.2     && <4
 
   hs-source-dirs:   src
   default-language: Haskell2010
@@ -50,26 +50,26 @@ library
 executable grpc-example-server
   main-is:          ExampleServer.hs
   build-depends:
-      async
-    , avro              >=0.4.7
+      async             >=2.2     && < 3
+    , avro              >=0.5.1   && <0.6
     , base              >=4.12    && <5
-    , binary
-    , bytestring
-    , conduit
-    , http2-grpc-types
-    , mtl
-    , mu-grpc-common    >=0.4.0
-    , mu-grpc-server
-    , mu-protobuf       >=0.4.0
-    , mu-rpc            >=0.4.0
-    , mu-schema         >=0.4.0
-    , sop-core
-    , stm
-    , stm-conduit
-    , wai
-    , warp
-    , warp-grpc         >=0.4.0.1
-    , warp-tls
+    , binary            >=0.8     && <0.9
+    , bytestring        >=0.10    && <0.11
+    , conduit           >=1.3.2   && <2
+    , http2-grpc-types  >=0.5     && <0.6
+    , mtl               >=2.2     && <3
+    , mu-grpc-common    ==0.4.*
+    , mu-grpc-server    ==0.4.*
+    , mu-protobuf       ==0.4.*
+    , mu-rpc            ==0.4.*
+    , mu-schema         ==0.3.*
+    , sop-core          >=0.5     && <0.6
+    , stm               >=2.5     && <3
+    , stm-conduit       >=4       && <5
+    , wai               >=3.2     && <4
+    , warp              >=3.3     && <4
+    , warp-grpc         >=0.4.0.1 && <0.5
+    , warp-tls          >=3.2     && <4
 
   hs-source-dirs:   exe
   default-language: Haskell2010

--- a/grpc/server/mu-grpc-server.cabal
+++ b/grpc/server/mu-grpc-server.cabal
@@ -34,7 +34,7 @@ library
     , mu-grpc-common    >=0.4.0
     , mu-protobuf       >=0.4.0
     , mu-rpc            >=0.4.0
-    , mu-schema         >=0.3.0
+    , mu-schema         >=0.4.0
     , sop-core
     , stm
     , stm-conduit
@@ -62,7 +62,7 @@ executable grpc-example-server
     , mu-grpc-server
     , mu-protobuf       >=0.4.0
     , mu-rpc            >=0.4.0
-    , mu-schema         >=0.3.0
+    , mu-schema         >=0.4.0
     , sop-core
     , stm
     , stm-conduit

--- a/instrumentation/prometheus/mu-prometheus.cabal
+++ b/instrumentation/prometheus/mu-prometheus.cabal
@@ -25,13 +25,13 @@ library
 
   build-depends:
       base                  >=4.12 && <5
-    , lifted-base
-    , monad-control
-    , mu-rpc                >=0.4.0
-    , prometheus-client
-    , text
-    , wai
-    , wai-middleware-prometheus
+    , lifted-base           >=0.2  && <0.3
+    , monad-control         >1     && <2
+    , mu-rpc                ==0.4.*
+    , prometheus-client     >1     && <2
+    , text                  >=1.2  && <2
+    , wai                   >=3.2  && <4
+    , wai-middleware-prometheus >1 && <2
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/stack-14.yaml
+++ b/stack-14.yaml
@@ -28,13 +28,14 @@ extra-deps:
 - http2-grpc-types-0.5.0.0
 - proto3-wire-1.1.0
 - warp-grpc-0.4.0.1
-- hw-kafka-client-3.0.0
-- hw-kafka-conduit-2.6.0
+- hw-kafka-client-3.1.1
+- hw-kafka-conduit-2.7.0
+- wai-middleware-prometheus-1.0.0
 - git: https://github.com/hasura/graphql-parser-hs.git
-  commit: ba2379640248ce67cdfe700cbb79acd91c644bdb
+  commit: f4a093981ca5626982a17c2bfaad047cc0834a81
 # missing in LTS 14.x
 - AC-Angle-1.0
-- avro-0.5.1.0
+- avro-0.5.2.0
 - conduit-1.3.2
 - HasBigDecimal-0.1.1
 - indexed-profunctors-0.1
@@ -43,9 +44,8 @@ extra-deps:
 - optics-core-0.2
 - primitive-0.7.0.0
 - primitive-extras-0.8
-- primitive-unlifted-0.1.2.0
+- primitive-unlifted-0.1.3.0
 - regex-base-0.94.0.0
 - regex-tdfa-1.3.1.0
 - stm-hamt-1.2.0.4
 - stm-containers-1.1.0.4
-- wai-middleware-prometheus-1.0.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-06-08
+resolver: nightly-2020-06-29
 allow-newer: true
 
 packages:
@@ -28,10 +28,13 @@ extra-deps:
 - http2-grpc-types-0.5.0.0
 - proto3-wire-1.1.0
 - warp-grpc-0.4.0.1
-- hw-kafka-client-3.0.0
-- hw-kafka-conduit-2.6.0
-- git: https://github.com/hasura/graphql-parser-hs.git
-  commit: ba2379640248ce67cdfe700cbb79acd91c644bdb
-- avro-0.5.1.0
-- language-avro-0.1.3.1
+- hw-kafka-client-3.1.1
+- hw-kafka-conduit-2.7.0
 - wai-middleware-prometheus-1.0.0
+- git: https://github.com/hasura/graphql-parser-hs.git
+  commit: f4a093981ca5626982a17c2bfaad047cc0834a81
+# Dropped in LTS 16
+- primitive-extras-0.8
+- primitive-unlifted-0.1.3.0
+- stm-hamt-1.2.0.4
+- stm-containers-1.1.0.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.16
+resolver: lts-16.3
 allow-newer: true
 
 packages:
@@ -28,10 +28,13 @@ extra-deps:
 - http2-grpc-types-0.5.0.0
 - proto3-wire-1.1.0
 - warp-grpc-0.4.0.1
-- hw-kafka-client-3.0.0
-- hw-kafka-conduit-2.6.0
-- git: https://github.com/hasura/graphql-parser-hs.git
-  commit: ba2379640248ce67cdfe700cbb79acd91c644bdb
-- avro-0.5.1.0
-- language-avro-0.1.3.1
+- hw-kafka-client-3.1.1
+- hw-kafka-conduit-2.7.0
 - wai-middleware-prometheus-1.0.0
+- git: https://github.com/hasura/graphql-parser-hs.git
+  commit: f4a093981ca5626982a17c2bfaad047cc0834a81
+# Dropped in LTS 16
+- primitive-extras-0.8
+- primitive-unlifted-0.1.3.0
+- stm-hamt-1.2.0.4
+- stm-containers-1.1.0.4


### PR DESCRIPTION
Fixes #191 

## TODO*
- [x] `adapter/protobuf`
- [x] `grpc/client`
- [x] `grpc/common`
- [x] `grpc/server`

---
* Packages I wasn't able to generate boundaries automatically