### PR TITLE
[WIP] Servant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ stack*.yaml.lock
 *~
 dist*
 *.pyc
+.*sw?
 
 ## User files
 .DS_Store

--- a/cabal.project
+++ b/cabal.project
@@ -19,6 +19,7 @@ packages: compendium-client/
           grpc/client/
           grpc/server/
           graphql/
+          servant/server/
           instrumentation/prometheus/
           instrumentation/tracing/
 

--- a/core/rpc/mu-rpc.cabal
+++ b/core/rpc/mu-rpc.cabal
@@ -28,7 +28,8 @@ library
     Mu.Server
 
   build-depends:
-      base              >=4.12  && <5
+      aeson
+    , base              >=4.12  && <5
     , conduit           >=1.3.2 && <1.4
     , http-types        >=0.12  && <0.13
     , mtl               >=2.2   && <2.3

--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -1,6 +1,7 @@
 {-# language DataKinds             #-}
 {-# language DeriveAnyClass        #-}
 {-# language DeriveGeneric         #-}
+{-# language DerivingVia           #-}
 {-# language FlexibleContexts      #-}
 {-# language FlexibleInstances     #-}
 {-# language GADTs                 #-}
@@ -20,12 +21,14 @@ Look at the source code of this module.
 -}
 module Mu.Rpc.Examples where
 
+import qualified Data.Aeson as J
 import           Data.Conduit
 import           Data.Conduit.Combinators as C
 import qualified Data.Text                as T
 import           GHC.Generics
 import           GHC.TypeLits
 
+import           Mu.Adapter.Json ()
 import           Mu.Rpc
 import           Mu.Schema
 import           Mu.Server
@@ -59,16 +62,22 @@ newtype HelloRequest = HelloRequest { name :: T.Text }
   deriving ( Show, Eq, Generic
            , ToSchema   QuickstartSchema "HelloRequest"
            , FromSchema QuickstartSchema "HelloRequest" )
+  deriving (J.ToJSON, J.FromJSON)
+    via (WithSchema QuickstartSchema "HelloRequest" HelloRequest)
 
 newtype HelloResponse = HelloResponse { message :: T.Text }
   deriving ( Show, Eq, Generic
            , ToSchema   QuickstartSchema "HelloResponse"
            , FromSchema QuickstartSchema "HelloResponse" )
+  deriving (J.ToJSON, J.FromJSON)
+    via (WithSchema QuickstartSchema "HelloResponse" HelloResponse)
 
 newtype HiRequest = HiRequest { number :: Int }
   deriving ( Show, Eq, Generic
            , ToSchema   QuickstartSchema "HiRequest"
            , FromSchema QuickstartSchema "HiRequest" )
+  deriving (J.ToJSON, J.FromJSON)
+    via (WithSchema QuickstartSchema "HiRequest" HiRequest)
 
 quickstartServer :: forall m i. (MonadServer m)
                  => ServerT '[] i QuickStartService m _

--- a/core/rpc/src/Mu/Rpc/Examples.hs
+++ b/core/rpc/src/Mu/Rpc/Examples.hs
@@ -53,7 +53,7 @@ type QuickStartService
             ('RetStream ('SchemaRef QuickstartSchema "HelloResponse"))
         , 'Method "SayManyHellos"
           '[ 'ArgStream ('Nothing @Symbol) ('SchemaRef QuickstartSchema "HelloRequest")]
-                ('RetStream ('SchemaRef QuickstartSchema "HelloResponse")) ] ]
+                ('RetStream ('SchemaRef QuickstartSchema "HelloResponse")) ] ] :: Package'
 
 newtype HelloRequest = HelloRequest { name :: T.Text }
   deriving ( Show, Eq, Generic

--- a/servant/server/CHANGELOG.md
+++ b/servant/server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for mu-haskell
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/servant/server/LICENSE
+++ b/servant/server/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright © 2019-2020 47 Degrees. <http://47deg.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/servant/server/Setup.hs
+++ b/servant/server/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Main where
+
+import Data.Aeson
+import Data.Conduit
+import Mu.Rpc.Examples
+import Mu.Servant.Server
+import Mu.Server
+import Network.Wai.Handler.Warp
+import Servant
+
+main :: IO ()
+main = do
+  putStrLn "running quickstart application"
+  run 8081 (serve (Proxy @API) servantServer)
+
+servantServer :: Server (PackageAPI QuickStartService (Handlers ServerErrorIO))
+servantServer = servantServerHandlers toHandler quickstartServer
+
+type API = PackageAPI QuickStartService (Handlers ServerErrorIO)
+
+type Handlers m =
+  '[  '[ HelloRequest -> m HelloResponse,
+         HiRequest -> ConduitT HelloResponse Void m () -> m (),
+         ConduitT () HelloRequest m () ->
+         ConduitT HelloResponse Void m () ->
+         m ()
+       ]
+   ]
+
+instance FromJSON HelloRequest
+
+instance FromJSON HiRequest
+
+instance ToJSON HelloResponse
+--deriving instance Generic HelloResponse
+{-
+    sayHello :: HelloRequest -> m HelloResponse
+    sayHello (HelloRequest nm)
+      = pure $ HelloResponse $ "hi, " <> nm
+    sayHi :: HiRequest
+          -> ConduitT HelloResponse Void m ()
+          -> m ()
+    sayHi (HiRequest n) sink
+      = runConduit $ C.replicate n (HelloResponse "hi!") .| sink
+    sayManyHellos :: ConduitT () HelloRequest m ()
+                  -> ConduitT HelloResponse Void m ()
+                  -> m ()
+    sayManyHellos source sink
+      = runConduit $ source .| C.mapM sayHello .| sink
+-}

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -8,6 +8,7 @@ module Main where
 import qualified Data.Text.IO as Text
 import Mu.Rpc.Annotations
 import Mu.Rpc.Examples
+import Mu.Schema.Annotations
 import Mu.Servant.Server
 import Network.Wai.Handler.Warp
 import Servant
@@ -39,3 +40,17 @@ type instance
 type instance
   AnnotatedPackage ServantStatus QuickStartService =
     '[]
+
+type instance
+  AnnotatedSchema ServantUnaryContentTypes QuickstartSchema =
+    '[ 'AnnType "HelloRequest" ('ServantUnaryContentTypes '[JSON]),
+       'AnnType "HelloResponse" ('ServantUnaryContentTypes '[JSON]),
+       'AnnType "HiRequest" ('ServantUnaryContentTypes '[JSON])
+     ]
+
+type instance
+  AnnotatedSchema ServantStreamContentType QuickstartSchema =
+    '[ 'AnnType "HelloRequest" ('ServantStreamContentType NewlineFraming JSON),
+       'AnnType "HelloResponse" ('ServantStreamContentType NewlineFraming JSON),
+       'AnnType "HiRequest" ('ServantStreamContentType NewlineFraming JSON)
+     ]

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -1,38 +1,29 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Main where
 
 import Data.Aeson
-import Data.Conduit
 import qualified Data.Text.IO as Text
 import Mu.Rpc.Annotations
 import Mu.Rpc.Examples
 import Mu.Servant.Server
-import Mu.Server
 import Network.Wai.Handler.Warp
 import Servant
 
 main :: IO ()
 main = do
   putStrLn "running quickstart application"
-  Text.putStrLn $ layout (Proxy @API)
-  run 8081 (serve (Proxy @API) servantServer)
+  Text.putStrLn $ layout quickstartAPI
+  run 8081 (serve quickstartAPI servantServer)
 
-servantServer :: Server (PackageAPI QuickStartService (Handlers ServerErrorIO))
+servantServer :: _
 servantServer = servantServerHandlers toHandler quickstartServer
 
-type API = PackageAPI QuickStartService (Handlers ServerErrorIO)
-
-type Handlers m =
-  '[  '[ HelloRequest -> m HelloResponse,
-         HiRequest -> ConduitT HelloResponse Void m () -> m (),
-         ConduitT () HelloRequest m () -> ConduitT HelloResponse Void m () -> m ()
-       ]
-   ]
+quickstartAPI :: Proxy _
+quickstartAPI = packageAPI quickstartServer
 
 instance FromJSON HelloRequest
 
@@ -47,3 +38,4 @@ type instance
        'AnnMethod "Greeter" "SayHi" '["say", "hi"],
        'AnnMethod "Greeter" "SayManyHellos" '["say", "many", "hellos"]
      ]
+

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -32,3 +32,10 @@ type instance
        'AnnMethod "Greeter" "SayManyHellos" '["say", "many", "hellos"]
      ]
 
+type instance
+  AnnotatedPackage ServantMethod QuickStartService =
+    '[]
+
+type instance
+  AnnotatedPackage ServantStatus QuickStartService =
+    '[]

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -9,6 +9,7 @@ module Main where
 import Data.Aeson
 import Data.Conduit
 import qualified Data.Text.IO as Text
+import Mu.Rpc.Annotations
 import Mu.Rpc.Examples
 import Mu.Servant.Server
 import Mu.Server
@@ -38,3 +39,11 @@ instance FromJSON HelloRequest
 instance FromJSON HiRequest
 
 instance ToJSON HelloResponse
+
+type instance
+  AnnotatedPackage ServantRoute QuickStartService =
+    '[ 'AnnService "Greeter" '["greet"],
+       'AnnMethod "Greeter" "SayHello" '["say", "hello"],
+       'AnnMethod "Greeter" "SayHi" '["say", "hi"],
+       'AnnMethod "Greeter" "SayManyHellos" '["say", "many", "hellos"]
+     ]

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# language DataKinds             #-}
+{-# language OverloadedStrings     #-}
+{-# language PartialTypeSignatures #-}
+{-# language TypeFamilies          #-}
 
 module Main where
 
-import qualified Data.Text.IO as Text
-import Mu.Rpc.Annotations
-import Mu.Rpc.Examples
-import Mu.Schema.Annotations
-import Mu.Servant.Server
-import Network.Wai.Handler.Warp
-import Servant
+import qualified Data.Text.IO             as Text
+import           Mu.Rpc.Annotations
+import           Mu.Rpc.Examples
+import           Mu.Schema.Annotations
+import           Mu.Servant.Server
+import           Network.Wai.Handler.Warp
+import           Servant
 
 main :: IO ()
 main = do

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -27,10 +27,10 @@ quickstartAPI = packageAPI quickstartServer
 
 type instance
   AnnotatedPackage ServantRoute QuickStartService =
-    '[ 'AnnService "Greeter" '["greet"],
-       'AnnMethod "Greeter" "SayHello" '["say", "hello"],
-       'AnnMethod "Greeter" "SayHi" '["say", "hi"],
-       'AnnMethod "Greeter" "SayManyHellos" '["say", "many", "hellos"]
+    '[ 'AnnService "Greeter" ('ServantRoute '["greet"]),
+       'AnnMethod "Greeter" "SayHello" ('ServantRoute '["say", "hello"]),
+       'AnnMethod "Greeter" "SayHi" ('ServantRoute '["say", "hi"]),
+       'AnnMethod "Greeter" "SayManyHellos" ('ServantRoute '["say", "many", "hellos"])
      ]
 
 type instance

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -8,6 +8,7 @@ module Main where
 
 import Data.Aeson
 import Data.Conduit
+import qualified Data.Text.IO as Text
 import Mu.Rpc.Examples
 import Mu.Servant.Server
 import Mu.Server
@@ -17,6 +18,7 @@ import Servant
 main :: IO ()
 main = do
   putStrLn "running quickstart application"
+  Text.putStrLn $ layout (Proxy @API)
   run 8081 (serve (Proxy @API) servantServer)
 
 servantServer :: Server (PackageAPI QuickStartService (Handlers ServerErrorIO))
@@ -27,9 +29,7 @@ type API = PackageAPI QuickStartService (Handlers ServerErrorIO)
 type Handlers m =
   '[  '[ HelloRequest -> m HelloResponse,
          HiRequest -> ConduitT HelloResponse Void m () -> m (),
-         ConduitT () HelloRequest m () ->
-         ConduitT HelloResponse Void m () ->
-         m ()
+         ConduitT () HelloRequest m () -> ConduitT HelloResponse Void m () -> m ()
        ]
    ]
 
@@ -38,19 +38,3 @@ instance FromJSON HelloRequest
 instance FromJSON HiRequest
 
 instance ToJSON HelloResponse
---deriving instance Generic HelloResponse
-{-
-    sayHello :: HelloRequest -> m HelloResponse
-    sayHello (HelloRequest nm)
-      = pure $ HelloResponse $ "hi, " <> nm
-    sayHi :: HiRequest
-          -> ConduitT HelloResponse Void m ()
-          -> m ()
-    sayHi (HiRequest n) sink
-      = runConduit $ C.replicate n (HelloResponse "hi!") .| sink
-    sayManyHellos :: ConduitT () HelloRequest m ()
-                  -> ConduitT HelloResponse Void m ()
-                  -> m ()
-    sayManyHellos source sink
-      = runConduit $ source .| C.mapM sayHello .| sink
--}

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -5,7 +5,6 @@
 
 module Main where
 
-import Data.Aeson
 import qualified Data.Text.IO as Text
 import Mu.Rpc.Annotations
 import Mu.Rpc.Examples
@@ -24,12 +23,6 @@ servantServer = servantServerHandlers toHandler quickstartServer
 
 quickstartAPI :: Proxy _
 quickstartAPI = packageAPI quickstartServer
-
-instance FromJSON HelloRequest
-
-instance FromJSON HiRequest
-
-instance ToJSON HelloResponse
 
 type instance
   AnnotatedPackage ServantRoute QuickStartService =

--- a/servant/server/hie.yaml
+++ b/servant/server/hie.yaml
@@ -1,0 +1,6 @@
+cradle:
+  stack:
+    - path: "./src"
+      component: "mu-servant-server:lib"
+    - path: "./exe"
+      component: "mu-servant-server:exe:servant-example-server"

--- a/servant/server/mu-servant-server.cabal
+++ b/servant/server/mu-servant-server.cabal
@@ -47,6 +47,7 @@ executable servant-example-server
     , base
     , conduit
     , mu-rpc
+    , mu-schema
     , mu-servant-server
     , servant-server
     , text

--- a/servant/server/mu-servant-server.cabal
+++ b/servant/server/mu-servant-server.cabal
@@ -23,9 +23,11 @@ source-repository head
 library
   exposed-modules:  Mu.Servant.Server
   build-depends:
-      async
+      aeson
+    , async
     , base
     , conduit
+    , generic-aeson
     , mtl
     , mu-rpc
     , mu-schema
@@ -47,6 +49,7 @@ executable servant-example-server
     , mu-rpc
     , mu-servant-server
     , servant-server
+    , text
     , warp
 
   hs-source-dirs:   exe

--- a/servant/server/mu-servant-server.cabal
+++ b/servant/server/mu-servant-server.cabal
@@ -1,0 +1,54 @@
+name:               mu-servant-server
+version:            0.4.0.0
+synopsis:           Servant servers for Mu definitions
+description:
+  With @mu-servant-server@ you can easily build Servant servers for mu-haskell!
+
+license:            Apache-2.0
+license-file:       LICENSE
+author:             Temp Name
+maintainer:         alejandro.serrano@47deg.com
+copyright:          Copyright © 2019-2020 <http://47deg.com 47 Degrees>
+cabal-version:      >=1.10
+category:           Network
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+homepage:           https://higherkindness.io/mu-haskell/
+bug-reports:        https://github.com/higherkindness/mu-haskell/issues
+
+source-repository head
+  type:     git
+  location: https://github.com/higherkindness/mu-haskell
+
+library
+  exposed-modules:  Mu.Servant.Server
+  build-depends:
+      async
+    , base
+    , conduit
+    , mtl
+    , mu-rpc
+    , mu-schema
+    , servant
+    , servant-server
+    , stm
+    , utf8-string
+
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  ghc-options:      -Wall -fprint-potential-instances
+
+executable servant-example-server
+  main-is:          ExampleServer.hs
+  build-depends:
+      aeson
+    , base
+    , conduit
+    , mu-rpc
+    , mu-servant-server
+    , servant-server
+    , warp
+
+  hs-source-dirs:   exe
+  default-language: Haskell2010
+  ghc-options:      -Wall -fprint-explicit-kinds -fprint-explicit-foralls

--- a/servant/server/mu-servant-server.cabal
+++ b/servant/server/mu-servant-server.cabal
@@ -6,7 +6,7 @@ description:
 
 license:            Apache-2.0
 license-file:       LICENSE
-author:             Temp Name
+author:             Andre Marianiello
 maintainer:         alejandro.serrano@47deg.com
 copyright:          Copyright © 2019-2020 <http://47deg.com 47 Degrees>
 cabal-version:      >=1.10

--- a/servant/server/mu-servant-server.cabal
+++ b/servant/server/mu-servant-server.cabal
@@ -23,7 +23,7 @@ source-repository head
 library
   exposed-modules:  Mu.Servant.Server
   build-depends:
-      aeson
+      aeson                 >=1.4   && <2
     , async
     , base
     , conduit

--- a/servant/server/src/Mu/Servant/Server.hs
+++ b/servant/server/src/Mu/Servant/Server.hs
@@ -1,0 +1,214 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Mu.Servant.Server where
+
+import Conduit
+import Control.Concurrent.Async
+import Control.Concurrent.STM
+import Control.Monad.Except
+import Data.ByteString.Lazy.UTF8
+import Data.Kind
+import GHC.TypeLits
+import Mu.Rpc
+import Mu.Schema
+import Mu.Server
+import Servant
+import Servant.Types.SourceT
+
+toHandler :: ServerErrorIO a -> Handler a
+toHandler = Handler . withExceptT convertServerError
+
+convertServerError :: Mu.Server.ServerError -> Servant.ServerError
+convertServerError (Mu.Server.ServerError code msg) = case code of
+  Unknown -> err502 {errBody = fromString msg}
+  Unavailable -> err503 {errBody = fromString msg}
+  Unimplemented -> err501 {errBody = fromString msg}
+  Unauthenticated -> err401 {errBody = fromString msg}
+  Internal -> err500 {errBody = fromString msg}
+  Invalid -> err400 {errBody = fromString msg}
+  NotFound -> err404 {errBody = fromString msg}
+
+type CannotConvertToServantAPI mname args ret =
+  'Text "cannot convert" ':<>: 'ShowType mname ':<>: 'Text "to a Servant API"
+    ':$$: 'Text "args:" ':<>: 'ShowType args
+    ':$$: 'Text "ret:" ':<>: 'ShowType ret
+
+type CannotConstructServiceAPI srv = 'Text "cannot construct service API from" ':$$: 'ShowType srv
+
+servantServerHandlers ::
+  forall name services m chn handlers.
+  ( ServantServiceHandlers
+      ('Package ('Just name) services)
+      m
+      chn
+      services
+      handlers
+  ) =>
+  (forall a. m a -> Handler a) ->
+  Mu.Server.ServerT chn () ('Package ('Just name) services) m handlers ->
+  Servant.Server (ServicesAPI services handlers)
+servantServerHandlers f (Services svcs) =
+  servantServiceHandlers f (Proxy @('Package ('Just name) services)) svcs
+
+type family PackageAPI (pkg :: Package snm mnm anm (TypeRef snm)) handlers where
+  PackageAPI ('Package sname services) handlers = ServicesAPI services handlers
+
+class
+  ServantServiceHandlers
+    (fullP :: Package snm mnm anm (TypeRef snm))
+    (m :: Type -> Type)
+    (chn :: ServiceChain snm)
+    (ss :: [Service snm mnm anm (TypeRef snm)])
+    (hss :: [[Type]]) where
+  type ServicesAPI ss hss
+
+  servantServiceHandlers ::
+    (forall a. m a -> Handler a) ->
+    Proxy fullP ->
+    ServicesT chn info ss m hss ->
+    Servant.Server (ServicesAPI ss hss)
+
+instance ServantServiceHandlers fullP m chn '[] '[] where
+  type ServicesAPI '[] '[] = EmptyAPI
+  servantServiceHandlers _ _ S0 = emptyServer
+
+instance
+  ( ServantMethodHandlers
+      fullP
+      ('Service name methods)
+      m
+      chn
+      (MappingRight chn name)
+      methods
+      hs,
+    ServantServiceHandlers fullP m chn rest hss
+  ) =>
+  ServantServiceHandlers fullP m chn ('Service name methods ': rest) (hs ': hss)
+  where
+  type ServicesAPI ('Service name methods ': rest) (hs ': hss) = MethodsAPI methods hs :<|> ServicesAPI rest hss
+  servantServiceHandlers f pfullP (svr :<&>: rest) =
+    servantMethodHandlers
+      f
+      pfullP
+      (Proxy @('Service name methods))
+      svr
+      :<|> servantServiceHandlers f pfullP rest
+
+class
+  ServantMethodHandlers
+    (fullP :: Package snm mnm anm (TypeRef snm))
+    (fullS :: Service snm mnm anm (TypeRef snm))
+    (m :: Type -> Type)
+    (chn :: ServiceChain snm)
+    (inh :: Type)
+    (ms :: [Method snm mnm anm (TypeRef snm)])
+    (hs :: [Type]) where
+  type MethodsAPI ms hs
+  servantMethodHandlers ::
+    (forall a. m a -> Handler a) ->
+    Proxy fullP ->
+    Proxy fullS ->
+    HandlersT chn info inh ms m hs ->
+    Servant.Server (MethodsAPI ms hs)
+
+instance ServantMethodHandlers fullP fullS m chn inh '[] '[] where
+  type MethodsAPI '[] '[] = EmptyAPI
+  servantMethodHandlers _ _ _ H0 = emptyServer
+
+instance
+  ( ServantMethodHandler m args r h,
+    ServantMethodHandlers fullP fullS m chn () rest hs
+  ) =>
+  ServantMethodHandlers fullP fullS m chn () ('Method name args r ': rest) (h ': hs)
+  where
+  type MethodsAPI ('Method name args r ': rest) (h ': hs) = MethodAPI args r h :<|> MethodsAPI rest hs
+  servantMethodHandlers f pfullP pfullS (Hmore _ _ h rest) =
+    servantMethodHandler
+      f
+      (Proxy @args)
+      (Proxy @r)
+      (h NoRpcInfo ())
+      :<|> servantMethodHandlers f pfullP pfullS rest
+
+class
+  ServantMethodHandler
+    (m :: Type -> Type)
+    (args :: [Argument snm anm tyref])
+    (r :: Return snm tyref)
+    (h :: Type) where
+  type MethodAPI args r h
+  servantMethodHandler ::
+    (forall a. m a -> Handler a) ->
+    Proxy args ->
+    Proxy r ->
+    h ->
+    Servant.Server (MethodAPI args r h)
+
+instance ServantMethodHandler m '[] 'RetNothing (m ()) where
+  type MethodAPI '[] 'RetNothing (m ()) = Post '[JSON] ()
+  servantMethodHandler f _ _ = f
+
+instance ServantMethodHandler m '[] ('RetSingle rref) (m r) where
+  type MethodAPI '[] ('RetSingle rref) (m r) = Post '[JSON] r
+  servantMethodHandler f _ _ = f
+
+instance MonadIO m => ServantMethodHandler m '[] ('RetStream rref) (ConduitT r Void m () -> m ()) where
+  type
+    MethodAPI '[] ('RetStream rref) (ConduitT r Void m () -> m ()) =
+      StreamPost NewlineFraming JSON (SourceIO r)
+  servantMethodHandler f _ _ = sinkToSource f
+
+sinkToSource ::
+  forall r m.
+  MonadIO m =>
+  (forall a. m a -> Handler a) ->
+  (ConduitT r Void m () -> m ()) ->
+  Handler (SourceIO r)
+sinkToSource f sink = do
+  var <- liftIO newEmptyTMVarIO :: Handler (TMVar (Maybe r))
+  forwarder <- liftIO $ async (runHandler . f . sink . toTMVarConduit $ var)
+  let step :: forall b. (StepT IO r -> IO b) -> IO b
+      step k = do
+        nextOutput <- liftIO $ atomically $ takeTMVar var
+        case nextOutput of
+          Just r -> step (k . Yield r)
+          Nothing -> do
+            _ <- liftIO $ cancel forwarder
+            k Stop
+  pure $ SourceT step
+
+toTMVarConduit :: MonadIO m => TMVar (Maybe r) -> ConduitT r Void m ()
+toTMVarConduit var = do
+  x <- await
+  liftIO $ atomically $ putTMVar var x
+  toTMVarConduit var
+
+instance
+  (ServantMethodHandler m rest r mr) =>
+  ServantMethodHandler m ('ArgSingle anm aref ': rest) r (t -> mr)
+  where
+  type MethodAPI ('ArgSingle anm aref ': rest) r (t -> mr) = ReqBody '[JSON] t :> MethodAPI rest r mr
+  servantMethodHandler pm _ pr h t = servantMethodHandler pm (Proxy @rest) pr (h t)
+
+instance
+  (ServantMethodHandler m rest r mr) =>
+  ServantMethodHandler m ('ArgStream anm aref ': rest) r (ConduitT () t m () -> mr)
+  where
+  type
+    MethodAPI ('ArgStream anm aref ': rest) r (ConduitT () t m () -> mr) =
+      StreamBody NewlineFraming JSON (SourceIO t) :> MethodAPI rest r mr
+  servantMethodHandler pm _ pr h = servantMethodHandler pm (Proxy @rest) pr . h . sourceToSource
+
+sourceToSource :: SourceIO t -> ConduitT () t m ()
+sourceToSource = undefined

--- a/servant/server/src/Mu/Servant/Server.hs
+++ b/servant/server/src/Mu/Servant/Server.hs
@@ -12,7 +12,6 @@
 {-# language TypeFamilies          #-}
 {-# language TypeOperators         #-}
 {-# language UndecidableInstances  #-}
-{-# OPTIONS_GHC -Wall #-}
 
 -- |
 -- = Transforming a Mu server into a Servant server

--- a/servant/server/src/Mu/Servant/Server.hs
+++ b/servant/server/src/Mu/Servant/Server.hs
@@ -29,6 +29,7 @@ import Generics.Generic.Aeson
 import Mu.Rpc
 import Mu.Rpc.Annotations
 import Mu.Schema
+import Mu.Schema.Annotations
 import Mu.Server
 import Servant
 import Servant.Types.SourceT
@@ -128,12 +129,11 @@ instance ServantMethodHandlers pkg svc m chn inh '[] '[] where
   servantMethodHandlers _ _ _ H0 = emptyServer
 
 instance
-  ( ServantMethodHandler httpMethod httpStatus ctype m args ret h,
+  ( ServantMethodHandler httpMethod httpStatus m args ret h,
     ServantMethodHandlers pkg sname m chn () rest hs,
     HttpMethodFor pkg sname mname ~ httpMethod,
     HttpStatusFor pkg sname mname ~ httpStatus,
-    ContentTypeFor pkg sname mname ~ ctype,
-    Server (MethodAPI pkg sname ('Method mname args ret) h) ~ Server (HandlerAPI httpMethod httpStatus ctype args ret h)
+    Server (MethodAPI pkg sname ('Method mname args ret) h) ~ Server (HandlerAPI httpMethod httpStatus args ret h)
   ) =>
   ServantMethodHandlers pkg sname m chn () ('Method mname args ret ': rest) (h ': hs)
   where
@@ -146,7 +146,6 @@ instance
       f
       (Proxy @httpMethod)
       (Proxy @httpStatus)
-      (Proxy @ctype)
       (Proxy @args)
       (Proxy @ret)
       (h NoRpcInfo ())
@@ -158,11 +157,25 @@ type family MethodAPI pkg sname method h where
       ( HandlerAPI
           (HttpMethodFor pkg sname mname)
           (HttpStatusFor pkg sname mname)
-          (ContentTypeFor pkg sname mname)
           args
           ret
           h
       )
+
+data ServantAPIAnnotations
+  = ServantAPIAnnotations
+      { method :: ServantMethod,
+        status :: ServantStatus,
+        contentType :: Type
+      }
+
+newtype ServantUnaryContentTypes = ServantUnaryContentTypes [Type]
+
+data ServantStreamContentType
+  = ServantStreamContentType
+      { framing :: Type,
+        streamContentType :: Type
+      }
 
 type family HttpMethodFor pkg sname mname :: ServantMethod where
   HttpMethodFor pkg sname mname =
@@ -172,18 +185,26 @@ type family HttpStatusFor pkg sname mname :: ServantStatus where
   HttpStatusFor pkg sname mname =
     FromMaybe 200 (GetMethodAnnotationMay (AnnotatedPackage ServantStatus pkg) sname mname)
 
-type family ContentTypeFor pkg sname mname :: Type where
-  ContentTypeFor pkg sname mname =
-    UnwrapServantContentType
-      ( FromMaybe
-          ('ServantContentType JSON)
-          (GetMethodAnnotationMay (AnnotatedPackage ServantContentType pkg) sname mname)
-      )
+type family UnaryContentTypesFor (tyRef :: TypeRef sname) :: [Type] where
+  UnaryContentTypesFor ('SchemaRef schema typeName) =
+    UnwrapServantUnaryContentType (GetTypeAnnotation (AnnotatedSchema ServantUnaryContentTypes schema) typeName)
 
-newtype ServantContentType = ServantContentType Type
+type family UnwrapServantUnaryContentType (sctype :: ServantUnaryContentTypes) :: [Type] where
+  UnwrapServantUnaryContentType ('ServantUnaryContentTypes ctype) = ctype
 
-type family UnwrapServantContentType (sctype :: ServantContentType) :: Type where
-  UnwrapServantContentType ('ServantContentType ctype) = ctype
+type family StreamContentTypeFor (tyRef :: TypeRef sname) :: Type where
+  StreamContentTypeFor ('SchemaRef schema typeName) =
+    StreamContentType (GetTypeAnnotation (AnnotatedSchema ServantStreamContentType schema) typeName)
+
+type family StreamContentType (sct :: ServantStreamContentType) where
+  StreamContentType ('ServantStreamContentType _ ctype) = ctype
+
+type family StreamFramingFor (tyRef :: TypeRef sname) :: Type where
+  StreamFramingFor ('SchemaRef schema typeName) =
+    StreamFraming (GetTypeAnnotation (AnnotatedSchema ServantStreamContentType schema) typeName)
+
+type family StreamFraming (sct :: ServantStreamContentType) where
+  StreamFraming ('ServantStreamContentType framing _) = framing
 
 type ServantMethod = StdMethod
 
@@ -193,16 +214,14 @@ class
   ServantMethodHandler
     (httpMethod :: ServantMethod)
     (httpStatus :: ServantStatus)
-    (ctype :: Type)
     (m :: Type -> Type)
-    (args :: [Argument snm anm tyref])
-    (ret :: Return snm tyref)
+    (args :: [Argument snm anm (TypeRef snm)])
+    (ret :: Return snm (TypeRef snm))
     (h :: Type) where
   type
     HandlerAPI
-      (httpMethod :: ServantMethod)
-      (httpStatus :: ServantStatus)
-      (ctype :: Type)
+      httpMethod
+      httpStatus
       args
       ret
       h
@@ -210,32 +229,31 @@ class
     (forall a. m a -> Handler a) ->
     Proxy httpMethod ->
     Proxy httpStatus ->
-    Proxy ctype ->
     Proxy args ->
     Proxy ret ->
     h ->
-    Servant.Server (HandlerAPI httpMethod httpStatus ctype args ret h)
+    Servant.Server (HandlerAPI httpMethod httpStatus args ret h)
 
-instance ServantMethodHandler httpMethod httpStatus ctype m '[] 'RetNothing (m ()) where
+instance ServantMethodHandler httpMethod httpStatus m '[] 'RetNothing (m ()) where
   type
-    HandlerAPI httpMethod httpStatus ctype '[] 'RetNothing (m ()) =
-      Verb httpMethod httpStatus '[ctype] ()
-  servantMethodHandler f _ _ _ _ _ = f
+    HandlerAPI httpMethod httpStatus '[] 'RetNothing (m ()) =
+      Verb httpMethod httpStatus '[] NoContent
+  servantMethodHandler f _ _ _ _ = fmap (const NoContent) . f
 
-instance ServantMethodHandler httpMethod httpStatus ctype m '[] ('RetSingle rref) (m r) where
+instance ServantMethodHandler httpMethod httpStatus m '[] ('RetSingle rref) (m r) where
   type
-    HandlerAPI httpMethod httpStatus ctype '[] ('RetSingle rref) (m r) =
-      Verb httpMethod httpStatus '[JSON] r
-  servantMethodHandler f _ _ _ _ _ = f
+    HandlerAPI httpMethod httpStatus '[] ('RetSingle rref) (m r) =
+      Verb httpMethod httpStatus (UnaryContentTypesFor rref) r
+  servantMethodHandler f _ _ _ _ = f
 
 instance
   (MonadServer m) =>
-  ServantMethodHandler httpMethod httpStatus ctype m '[] ('RetStream rref) (ConduitT r Void m () -> m ())
+  ServantMethodHandler httpMethod httpStatus m '[] ('RetStream rref) (ConduitT r Void m () -> m ())
   where
   type
-    HandlerAPI httpMethod httpStatus ctype '[] ('RetStream rref) (ConduitT r Void m () -> m ()) =
-      Stream httpMethod httpStatus NewlineFraming JSON (SourceIO (StreamResult r))
-  servantMethodHandler f _ _ _ _ _ = liftIO . sinkToSource f
+    HandlerAPI httpMethod httpStatus '[] ('RetStream rref) (ConduitT r Void m () -> m ()) =
+      Stream httpMethod httpStatus (StreamFramingFor rref) (StreamContentTypeFor rref) (SourceIO (StreamResult r))
+  servantMethodHandler f _ _ _ _ = liftIO . sinkToSource f
 
 data StreamResult a = Error String | Result a
   deriving (Generic, Show)
@@ -281,25 +299,25 @@ toMVarConduit var = do
       toMVarConduit var
 
 instance
-  (ServantMethodHandler httpMethod httpStatus ctype m rest ret h) =>
-  ServantMethodHandler httpMethod httpStatus ctype m ('ArgSingle anm aref ': rest) ret (t -> h)
+  (ServantMethodHandler httpMethod httpStatus m rest ret h) =>
+  ServantMethodHandler httpMethod httpStatus m ('ArgSingle anm aref ': rest) ret (t -> h)
   where
   type
-    HandlerAPI httpMethod httpStatus ctype ('ArgSingle anm aref ': rest) ret (t -> h) =
-      ReqBody '[JSON] t :> HandlerAPI httpMethod httpStatus ctype rest ret h
-  servantMethodHandler f mP sP mCt _ retP h t =
-    servantMethodHandler f mP sP mCt (Proxy @rest) retP (h t)
+    HandlerAPI httpMethod httpStatus ('ArgSingle anm aref ': rest) ret (t -> h) =
+      ReqBody (UnaryContentTypesFor aref) t :> HandlerAPI httpMethod httpStatus rest ret h
+  servantMethodHandler f mP sP _ retP h t =
+    servantMethodHandler f mP sP (Proxy @rest) retP (h t)
 
 instance
-  (MonadServer m, ServantMethodHandler httpMethod httpStatus ctype m rest ret h) =>
-  ServantMethodHandler httpMethod httpStatus ctype m ('ArgStream anm aref ': rest) ret (ConduitT () t m () -> h)
+  (MonadServer m, ServantMethodHandler httpMethod httpStatus m rest ret h) =>
+  ServantMethodHandler httpMethod httpStatus m ('ArgStream anm aref ': rest) ret (ConduitT () t m () -> h)
   where
   type
-    HandlerAPI httpMethod httpStatus ctype ('ArgStream anm aref ': rest) ret (ConduitT () t m () -> h) =
-      StreamBody NewlineFraming JSON (SourceIO t)
-        :> HandlerAPI httpMethod httpStatus ctype rest ret h
-  servantMethodHandler f mP sP mCt _ retP h =
-    servantMethodHandler f mP sP mCt (Proxy @rest) retP . h . sourceToSource
+    HandlerAPI httpMethod httpStatus ('ArgStream anm aref ': rest) ret (ConduitT () t m () -> h) =
+      StreamBody (StreamFramingFor aref) (StreamContentTypeFor aref) (SourceIO t)
+        :> HandlerAPI httpMethod httpStatus rest ret h
+  servantMethodHandler f mP sP _ retP h =
+    servantMethodHandler f mP sP (Proxy @rest) retP . h . sourceToSource
 
 sourceToSource :: (MonadServer m) => SourceIO t -> ConduitT () t m ()
 sourceToSource (SourceT src) = ConduitT (PipeM (liftIO $ src (pure . go)) >>=)

--- a/servant/server/src/Mu/Servant/Server.hs
+++ b/servant/server/src/Mu/Servant/Server.hs
@@ -1,51 +1,51 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# language DataKinds             #-}
+{-# language DeriveGeneric         #-}
+{-# language FlexibleContexts      #-}
+{-# language FlexibleInstances     #-}
+{-# language GADTs                 #-}
+{-# language MultiParamTypeClasses #-}
+{-# language PolyKinds             #-}
+{-# language RankNTypes            #-}
+{-# language ScopedTypeVariables   #-}
+{-# language TypeApplications      #-}
+{-# language TypeFamilies          #-}
+{-# language TypeOperators         #-}
+{-# language UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wall #-}
 
 module Mu.Servant.Server where
 
-import Conduit
-import Control.Concurrent
-import Control.Concurrent.Async
-import Control.Monad.Except
-import Data.Aeson
+import           Conduit
+import           Control.Concurrent
+import           Control.Concurrent.Async
+import           Control.Monad.Except
+import           Data.Aeson
 import qualified Data.ByteString.Lazy.UTF8 as LB8
-import Data.Conduit.Internal (ConduitT (..), Pipe (..))
-import Data.Kind
-import GHC.Generics
-import GHC.TypeLits
-import Generics.Generic.Aeson
-import Mu.Rpc
-import Mu.Rpc.Annotations
-import Mu.Schema
-import Mu.Schema.Annotations
-import Mu.Server
-import Servant
-import Servant.Types.SourceT
+import           Data.Conduit.Internal     (ConduitT (..), Pipe (..))
+import           Data.Kind
+import           Generics.Generic.Aeson
+import           GHC.Generics
+import           GHC.TypeLits
+import           Mu.Rpc
+import           Mu.Rpc.Annotations
+import           Mu.Schema
+import           Mu.Schema.Annotations
+import           Mu.Server
+import           Servant
+import           Servant.Types.SourceT
 
 toHandler :: ServerErrorIO a -> Handler a
 toHandler = Handler . withExceptT convertServerError
 
 convertServerError :: Mu.Server.ServerError -> Servant.ServerError
 convertServerError (Mu.Server.ServerError code msg) = case code of
-  Unknown -> err502 {errBody = LB8.fromString msg}
-  Unavailable -> err503 {errBody = LB8.fromString msg}
-  Unimplemented -> err501 {errBody = LB8.fromString msg}
+  Unknown         -> err502 {errBody = LB8.fromString msg}
+  Unavailable     -> err503 {errBody = LB8.fromString msg}
+  Unimplemented   -> err501 {errBody = LB8.fromString msg}
   Unauthenticated -> err401 {errBody = LB8.fromString msg}
-  Internal -> err500 {errBody = LB8.fromString msg}
-  Invalid -> err400 {errBody = LB8.fromString msg}
-  NotFound -> err404 {errBody = LB8.fromString msg}
+  Internal        -> err500 {errBody = LB8.fromString msg}
+  Invalid         -> err400 {errBody = LB8.fromString msg}
+  NotFound        -> err404 {errBody = LB8.fromString msg}
 
 servantServerHandlers ::
   forall pname m chn ss handlers.
@@ -164,8 +164,8 @@ type family MethodAPI pkg sname method h where
 
 data ServantAPIAnnotations
   = ServantAPIAnnotations
-      { method :: ServantMethod,
-        status :: ServantStatus,
+      { method      :: ServantMethod,
+        status      :: ServantStatus,
         contentType :: Type
       }
 
@@ -173,7 +173,7 @@ newtype ServantUnaryContentTypes = ServantUnaryContentTypes [Type]
 
 data ServantStreamContentType
   = ServantStreamContentType
-      { framing :: Type,
+      { framing           :: Type,
         streamContentType :: Type
       }
 

--- a/stack-14.yaml
+++ b/stack-14.yaml
@@ -14,6 +14,7 @@ packages:
 - grpc/client
 - grpc/server
 - graphql
+- servant/server
 - instrumentation/prometheus
 - instrumentation/tracing
 - examples/health-check

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -14,6 +14,7 @@ packages:
 - grpc/client
 - grpc/server
 - graphql
+- servant/server
 - instrumentation/prometheus
 - instrumentation/tracing
 - examples/health-check

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,7 @@ packages:
 - grpc/client
 - grpc/server
 - graphql
+- servant/server
 - instrumentation/prometheus
 - instrumentation/tracing
 - examples/health-check

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,6 +38,7 @@ extra-deps:
 - wai-middleware-prometheus-1.0.0
 - git: https://github.com/hasura/graphql-parser-hs.git
   commit: f4a093981ca5626982a17c2bfaad047cc0834a81
+- generic-aeson-0.2.0.10
 # Dropped in LTS 16
 - primitive-extras-0.8
 - primitive-unlifted-0.1.3.0


### PR DESCRIPTION
I need to add support for putting paths in the API (probably something like /serviceName/methodName), but there is enough here to take a look. I would absolutely love it if the API could be generated from the service+schema only, but I didn't know how to convert a typeref into a haskell type, so I am currently using the handler types to direct that instead. Would appreciate any tips on that front. Additionally, we probably want to not restrict ourselves to just JSON, but I went with that for simplicity. Also, eventually, I would love to use protobuf options to direct the Service->API mapping, ala https://github.com/grpc-ecosystem/grpc-gateway, but I don't think that necessarily needs to be in this PR.

Fixes #215 