### PR TITLE
Conversion to logical types

### DIFF
--- a/core/schema/mu-schema.cabal
+++ b/core/schema/mu-schema.cabal
@@ -1,5 +1,5 @@
 name:               mu-schema
-version:            0.3.0.0
+version:            0.3.1.0
 synopsis:           Format-independent schemas for serialization
 description:
   With @mu-schema@ you can describe schemas using type-level constructs, and derive serializers from those. See @mu-avro@, @mu-protobuf@ for the actual adapters.
@@ -47,6 +47,7 @@ library
     , text                  >=1.2   && <2
     , th-abstraction        >=0.3.2 && <0.4
     , unordered-containers  >=0.2   && <0.3
+    , uuid                  >=1.3   && <2
     , vector                >=0.12  && <0.13
 
   hs-source-dirs:   src

--- a/core/schema/src/Mu/Schema.hs
+++ b/core/schema/src/Mu/Schema.hs
@@ -29,6 +29,7 @@ module Mu.Schema (
 , FromSchema(..), fromSchema'
 , ToSchema(..), toSchema'
 , CustomFieldMapping(..)
+, Underlying(..), UnderlyingConversion(..)
   -- ** Mappings between fields
 , Mapping(..), Mappings, MappingRight, MappingLeft
   -- ** Field annotations


### PR DESCRIPTION
Fixes #208

This PR adds a new possibility when converting Haskell types from and to primitive types. Right now if the protocol defines that a certain type (let's say `bytes` in Protocol Buffers) maps to a certain Haskell types (`ByteString` in this case), the Haskell representation is forced to used that same type or write the conversion entirely by hand. When this is merged, you'll be able to do:

```haskell
data Msg = Msg { id :: Underlying ByteString UUID }
```

which specifies that on the wire we want to see the field as a `ByteString` but logically it is a `UUID`.

The conversion between wire and logical types is done via the `UnderlyingConversion` type class. Right now there are only instances for `UUID`, but more could be added here.

