### PR TITLE
Simpler routes in Servant

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -33,5 +33,6 @@ in {
   mu-protobuf = hnPkgs.mu-protobuf.components.library;
   mu-rpc = hnPkgs.mu-rpc.components.library;
   mu-schema = hnPkgs.mu-schema.components.library;
+  mu-servant-server = hnPkgs.mu-servant-server.components.library;
   mu-tracing = hnPkgs.mu-tracing.components.library;
 }

--- a/examples/health-check/src/Server.hs
+++ b/examples/health-check/src/Server.hs
@@ -151,32 +151,25 @@ instance MonadMonitor m => MonadMonitor (TraceT m)
 -- Information for servant
 
 type instance AnnotatedPackage ServantRoute HealthCheckServiceFS2
-  = '[ 'AnnService "HealthCheckServiceFS2" ('ServantRoute '["health"])
-     , 'AnnMethod "HealthCheckServiceFS2" "setStatus"   ('ServantRoute '["status"])
-     , 'AnnMethod "HealthCheckServiceFS2" "check"       ('ServantRoute '["status"])
-     , 'AnnMethod "HealthCheckServiceFS2" "clearStatus" ('ServantRoute '["status"])
-     , 'AnnMethod "HealthCheckServiceFS2" "checkAll"    ('ServantRoute '["all", "status"])
-     , 'AnnMethod "HealthCheckServiceFS2" "cleanAll"    ('ServantRoute '["all", "status"])
-     , 'AnnMethod "HealthCheckServiceFS2" "watch"       ('ServantRoute '["watch"])
+  = '[ 'AnnService "HealthCheckServiceFS2"
+                   ('ServantTopLevelRoute '["health"])
+     , 'AnnMethod "HealthCheckServiceFS2" "setStatus"
+                  ('ServantRoute '["status"] 'POST 200)
+     , 'AnnMethod "HealthCheckServiceFS2" "check"
+                  ('ServantRoute '["status"] 'GET 200)
+     , 'AnnMethod "HealthCheckServiceFS2" "clearStatus"
+                  ('ServantRoute '["status"] 'DELETE 200)
+     , 'AnnMethod "HealthCheckServiceFS2" "checkAll"
+                  ('ServantRoute '["all", "status"] 'GET 200)
+     , 'AnnMethod "HealthCheckServiceFS2" "cleanAll"
+                  ('ServantRoute '["all", "status"] 'DELETE 200)
+     , 'AnnMethod "HealthCheckServiceFS2" "watch"
+                  ('ServantRoute '["watch"] 'GET 200)
      ]
 
-type instance AnnotatedPackage ServantMethod HealthCheckService
-  = '[ 'AnnMethod "HealthCheckServiceFS2" "setStatus"   ('ServantMethod 'POST)
-     , 'AnnMethod "HealthCheckServiceFS2" "check"       ('ServantMethod 'GET)
-     , 'AnnMethod "HealthCheckServiceFS2" "clearStatus" ('ServantMethod 'DELETE)
-     , 'AnnMethod "HealthCheckServiceFS2" "checkAll"    ('ServantMethod 'GET)
-     , 'AnnMethod "HealthCheckServiceFS2" "cleanAll"    ('ServantMethod 'DELETE)
-     , 'AnnMethod "HealthCheckServiceFS2" "watch"       ('ServantMethod 'GET)
+type instance AnnotatedSchema ServantContentTypes HealthCheckSchema
+  = '[ 'AnnType "HealthCheck"  DefaultServantContentTypes
+     , 'AnnType "ServerStatus" DefaultServantContentTypes
+     , 'AnnType "HealthStatus" DefaultServantContentTypes
+     , 'AnnType "AllStatus"    DefaultServantContentTypes
      ]
-
-type instance AnnotatedPackage ServantStatus HealthCheckService = '[]
-
-type instance AnnotatedSchema ServantUnaryContentTypes HealthCheckSchema
-  = '[ 'AnnType "HealthCheck"  ('ServantUnaryContentTypes '[JSON])
-     , 'AnnType "ServerStatus" ('ServantUnaryContentTypes '[JSON])
-     , 'AnnType "HealthStatus" ('ServantUnaryContentTypes '[JSON])
-     , 'AnnType "AllStatus"    ('ServantUnaryContentTypes '[JSON])
-     ]
-
-type instance AnnotatedSchema ServantStreamContentType HealthCheckSchema
-  = '[ 'AnnType "ServerStatus" ('ServantStreamContentType NewlineFraming JSON) ]

--- a/servant/server/exe/ExampleServer.hs
+++ b/servant/server/exe/ExampleServer.hs
@@ -29,30 +29,18 @@ quickstartAPI = packageAPI (quickstartServer @ServerErrorIO)
 
 type instance
   AnnotatedPackage ServantRoute QuickStartService =
-    '[ 'AnnService "Greeter" ('ServantRoute '["greet"]),
-       'AnnMethod "Greeter" "SayHello" ('ServantRoute '["say", "hello"]),
-       'AnnMethod "Greeter" "SayHi" ('ServantRoute '["say", "hi"]),
-       'AnnMethod "Greeter" "SayManyHellos" ('ServantRoute '["say", "many", "hellos"])
+    '[ 'AnnService "Greeter" ('ServantTopLevelRoute '["greet"]),
+       'AnnMethod "Greeter" "SayHello"
+                  ('ServantRoute '["say", "hello"] 'POST 200),
+       'AnnMethod "Greeter" "SayHi"
+                  ('ServantRoute '["say", "hi"] 'POST 200),
+       'AnnMethod "Greeter" "SayManyHellos"
+                  ('ServantRoute '["say", "many", "hellos"] 'POST 200)
      ]
 
 type instance
-  AnnotatedPackage ServantMethod QuickStartService =
-    '[]
-
-type instance
-  AnnotatedPackage ServantStatus QuickStartService =
-    '[]
-
-type instance
-  AnnotatedSchema ServantUnaryContentTypes QuickstartSchema =
-    '[ 'AnnType "HelloRequest" ('ServantUnaryContentTypes '[JSON]),
-       'AnnType "HelloResponse" ('ServantUnaryContentTypes '[JSON]),
-       'AnnType "HiRequest" ('ServantUnaryContentTypes '[JSON])
-     ]
-
-type instance
-  AnnotatedSchema ServantStreamContentType QuickstartSchema =
-    '[ 'AnnType "HelloRequest" ('ServantStreamContentType NewlineFraming JSON),
-       'AnnType "HelloResponse" ('ServantStreamContentType NewlineFraming JSON),
-       'AnnType "HiRequest" ('ServantStreamContentType NewlineFraming JSON)
+  AnnotatedSchema ServantContentTypes QuickstartSchema =
+    '[ 'AnnType "HelloRequest" DefaultServantContentTypes,
+       'AnnType "HelloResponse" DefaultServantContentTypes,
+       'AnnType "HiRequest" DefaultServantContentTypes
      ]

--- a/servant/server/mu-servant-server.cabal
+++ b/servant/server/mu-servant-server.cabal
@@ -28,6 +28,7 @@ library
     , base
     , conduit
     , generic-aeson
+    , ghc-prim
     , mtl
     , mu-rpc
     , mu-schema


### PR DESCRIPTION
As discussed in #229, the information for serving a Mu server via Servant could be condensed in two annotations: one for the routes, and one for the serialization of schemas. This PR implements it, and also introduces a `DefaultServantContentTypes` for those who don't want to think about which content types to support (simply JSON on both unary and streaming mode).

Pinging @andremarianiello for comments.