### PR TITLE
Expose Swagger definition + SwaggerUI example

### DIFF
--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -22,7 +22,7 @@ options:
     - title: Mu-Optics
       url: optics/
 
-  - title: RPC services
+  - title: Services
     url: rpc/
     nested_options:
     - title: gRPC servers
@@ -31,8 +31,11 @@ options:
     - title: gRPC clients
       url: grpc/client/
 
-  - title: GraphQL services
-    url: graphql/
+    - title: GraphQL
+      url: graphql/
+
+    - title: OpenAPI / REST
+      url: openapi/
 
   - title: Integrations
     nested_options:

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -15,10 +15,11 @@ Mu-Haskell is a set of packages that help you build both servers and clients for
   * [Serialization formats]({% link docs/serializers.md %}): Protocol Buffers and Avro
   * [Registry]({% link docs/registry.md %})
   * [Optics]({% link docs/optics.md %})
-* [RPC services]({% link docs/rpc.md %})
+* [Services]({% link docs/rpc.md %})
   * [gRPC server]({% link docs/grpc-server.md %})
   * [gRPC client]({% link docs/grpc-client.md %})
-* [GraphQL services]({% link docs/graphql.md %})
+  * [GraphQL]({% link docs/graphql.md %})
+  * [OpenAPI / REST]({% link docs/rest.md %})
 * Integration with other libraries
   * [Databases]({% link docs/db.md %}), including resource pools
   * [Using transformers]({% link docs/transformer.md %}): look here for logging

--- a/docs/docs/rest.md
+++ b/docs/docs/rest.md
@@ -1,0 +1,7 @@
+---
+layout: docs
+title: OpenAPI / REST services
+permalink: openapi/
+---
+
+# OpenAPI / REST services

--- a/docs/docs/rest.md
+++ b/docs/docs/rest.md
@@ -5,3 +5,188 @@ permalink: openapi/
 ---
 
 # OpenAPI / REST services
+
+In order to expose a Mu server using a OpenAPI or REST interface, we make use of the awesome [Servant](https://docs.servant.dev/en/stable/) library. Both libraries describe the API of a server at the type level, use the notion of _handlers_, and follow a similar structure.
+
+The `mu-servant-server` package contains a function `servantServerHandlers` which unpacks the Mu handlers and repackages them as Servant handlers, with some minor changes to support streaming. The trickiest part, however, is translating the Mu server _type_ into a Servant server _type_.
+
+## Annotating the server
+
+When Mu methods are converted to Servant APIs, you may customize certain aspects of the resulting API, including the route, HTTP method, and HTTP status.  Additionally, you must specify which content types use be used when encoding and decoding each type in your schema that appears in your methods. All of this customization is done with annotations, via the `AnnotatedSchema` and `AnnotatedPackage` type families.
+
+For the server we have developed in the [generic RPC section]({% link docs/rpc.md %}), the instances for the services look as follows:
+
+```haskell
+type instance AnnotatedPackage ServantRoute QuickstartService
+  = '[ 'AnnService "Greeter" ('ServantTopLevelRoute '["greet"])
+     , 'AnnMethod "Greeter" "SayHello"
+                   ('ServantRoute '["say", "hello"] 'POST 200),
+     ]
+```
+
+The first annotation defines that the whole service lives in the `/greet` route. Each method then gets its own route and HTTP verb. To execute `SayHello`, one has to make a `POST` request to `/greet/say/hello`. The last element is the HTTP status code to be returned by default, in this case `200` which means success.
+
+You also need to define how message types can be serialized in the API. This will be translated to a `ReqBody` in the corresponding Servant API, which requires a list of acceptable content types for the request. We provide a `DefaultServantContentTypes` which uses JSON for both unary and streaming calls.
+
+```haskell
+type instance
+  AnnotatedSchema ServantContentTypes QuickstartSchema =
+    '[ 'AnnType "HelloRequest"  DefaultServantContentTypes,
+       'AnnType "HelloResponse" DefaultServantContentTypes
+     ]
+```
+
+The `MimeRender`/`MimeUnrender` instances necessary to perform this encoding/decoding must exist for the Haskell type you use to represent messages. In this case, that means that both types must support conversion to JSON, which can be achieved using `mu-schema` in combination with `DerivingVia`.
+
+```haskell
+{-# language DerivingVia #-}
+
+import qualified Data.Aeson as J
+import Mu.Adapter.Json ()
+
+newtype HelloRequest = HelloRequest { name :: T.Text }
+  deriving ( Show, Eq, Generic
+           , ToSchema   QuickstartSchema "HelloRequest"
+           , FromSchema QuickstartSchema "HelloRequest" )
+  deriving (J.ToJSON, J.FromJSON)
+    via (WithSchema QuickstartSchema "HelloRequest" HelloRequest)
+```
+
+
+If you forget to provide one of these required instances, you will see a message like the following:
+
+```
+    • Missing required AnnotatedPackage ServantRoute type instance
+      for "myschema" package
+    • When checking the inferred type
+```
+
+followed by a large and difficult to read type representing several stuck type families.  This message is an indication that you must provide an `AnnotatedPackage` type instance, with a domain of `ServantRoute` for the package with the name `myschema`.
+
+## Exposing the server
+
+You are now ready to expose your server using Servant!
+
+```haskell
+import Mu.Servant.Server
+import Servant.Server
+
+main =
+  let api    = packageAPI (quickstartServer @ServerErrorIO)
+      server = servantServerHandlers toHandler quickstartServer
+  in run 8081 (serve api server)
+```
+
+The last line uses functions from Servant and Warp to run the server. The `serve` function has two parameters:
+- One is the definition of the API, which can be obtained using the provided `packageAPI` with your server. In this case we had to make explicit the monad we are operating to avoid an ambiguity error.
+- The other is the set of Servant handlers, which can be obtained by using `servantServerHandlers toHandler`.
+
+## Integration with Swagger UI
+
+You can easily expose not only the server itself, but also its [Swagger / OpenAPI](https://swagger.io/) schema easily, alongside a [Swagger UI](https://swagger.io/tools/swagger-ui/) for testing purposes. Here we make use of the awesome [`servant-swagger-ui` package](https://github.com/haskell-servant/servant-swagger-ui).
+
+First of all, you need to specify that you want an additional component in your Servant API. You do so in the annotation:
+
+```haskell
+type instance AnnotatedPackage ServantRoute QuickstartService
+  = '[ 'AnnPackage ('ServantAdditional (SwaggerSchemaUI "swagger-ui" "swagger.json"))
+     , {- rest of annotations -} ]
+```
+
+The implementation of this additional component is given by using `servantServerHandlersExtra`, instead of its "non-extra" version. The aforementioned package is ready for consumption in that way:
+
+```haskell
+import Mu.Servant.Server
+import Servant.Server
+import Servant.Swagger.UI
+
+main =
+  let svc    = quickstartServer @ServerErrorIO
+      api    = packageAPI svc
+      server = servantServerHandlersExtra
+                (swaggerSchemaUIServer (swagger svc))
+                toHandler svc
+  in run 8081 (serve api server)
+```
+
+And that's all! When you users surf to `yourserver/swagger-ui` they'll see a color- and featureful explanation of the endpoints of your server.
+
+## Type translation
+
+> This is not required for using `mu-servant-server`, but may help you understanding how it works under the hood and diagnosing problems.
+
+There are essentially four categories of `Method` types and each of these is translated slightly differently.
+
+### Full unary
+
+Full unary methods have non-streaming arguments and a non-streaming response. Most HTTP endpoints expect unary requests and return unary responses. Unary method handlers look like this
+
+```haskell
+(MonadServer m) => requestType -> m responseType
+```
+
+For a handler like this, the corresponding "Servant" API type would be
+
+```haskell
+type MyUnaryAPI =
+  route :>
+    ReqBody ctypes1 requestType :>
+      Verb method status ctypes2 responseType
+```
+
+As you can see, the request body contains a `requestType` value, and the response body contains a `responseType` value. All other types are derived from Mu annotations.
+
+### Server streaming
+
+Server streaming methods have non-streaming arguments, but the response is streamed back to the client. Server stream handlers look like this
+
+```haskell
+(MonadServer m) => requestType -> ConduitT responseType Void m () -> m ()
+```
+
+For a handler like this, the corresponding Servant API type would be
+
+```haskell
+type MyServerStreamAPI =
+  route :>
+    ReqBody ctypes requestType :>
+      Stream method status framing ctype (SourceIO (StreamResult responseType))
+```
+
+The request body contains a `requestType` value. The response body is a stream of `StreamResult` responseType@ values. `StreamResult responseType` contains either a `responseType` value or an error message describing a problem that occurred while producing `responseType` values. All other types are derived from Mu annotations.
+
+### Client streaming
+
+Client streaming methods have a streaming argument, but the response is unary. Client stream handlers look like this
+
+```haskell
+(MonadServer m) => ConduitT () requestType m () -> m responseType
+```
+
+For a handler like this, the corresponding Servant API type would be
+
+```haskell
+type MyClientStreamAPI =
+  route :>
+    StreamBody framing ctype (SourceIO requestType) :>
+      Verb method status ctypes responseType
+```
+
+### Bidirectional streaming
+
+Bidirectional streaming method have a streaming argument and a streaming response. Bidirectional stream handlers look like this
+
+```haskell
+> (MonadServer m) => ConduitT () requestType m () -> ConduitT responseType Void m () -> m()
+```
+
+For a handler like this, the corresponding Servant API type would be
+
+```haskell
+type MyBidirectionalStreamAPI =
+  StreamBody framing1 ctype1 (SourceIO requestType) :>
+    Stream method status framing2 ctype2 (SourceIO (StreamResult responseType))
+```
+
+This type should look familiar if you already looked at the server streaming and client streaming examples. The request body is a stream of `requestType` values, and the response body is a stream of `StreamResult responseType` values. All the other types involved are derived from Mu annotations.
+

--- a/examples/health-check/mu-example-health-check.cabal
+++ b/examples/health-check/mu-example-health-check.cabal
@@ -36,9 +36,11 @@ executable health-server
     , mu-tracing        >=0.4.0
     , prometheus-client >= 1    && <2
     , servant-server
+    , servant-swagger-ui
     , stm               >=2.5   && <3
     , stm-conduit       >=4     && <5
     , stm-containers    >=1.1   && <2
+    , swagger2
     , text              >=1.2   && <2
     , tracing-control   >=0.0.6
     , wai               >=3.2   && <4
@@ -59,6 +61,7 @@ executable health-client-tyapps
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
+    , swagger2
     , text            >=1.2   && <2
 
   hs-source-dirs:   src
@@ -76,6 +79,7 @@ executable health-client-record
     , mu-protobuf     >=0.4.0
     , mu-rpc          >=0.4.0
     , mu-schema       >=0.3.0
+    , swagger2
     , text            >=1.2   && <2
 
   hs-source-dirs:   src

--- a/examples/health-check/src/Definition.hs
+++ b/examples/health-check/src/Definition.hs
@@ -15,6 +15,7 @@
 module Definition where
 
 import qualified Data.Aeson      as J
+import qualified Data.Swagger    as Swagger
 import           Data.Text       as T
 import           GHC.Generics
 
@@ -34,27 +35,31 @@ newtype HealthCheckMsg
   = HealthCheckMsg { nameService :: T.Text }
   deriving ( Eq, Show, Ord, Generic
            , ToSchema   HealthCheckSchema "HealthCheck"
-           , FromSchema HealthCheckSchema "HealthCheck" )
+           , FromSchema HealthCheckSchema "HealthCheck"
+           , Swagger.ToSchema )
   deriving (J.ToJSON, J.FromJSON)
     via (WithSchema HealthCheckSchema "HealthCheck" HealthCheckMsg)
 newtype ServerStatusMsg
   = ServerStatusMsg { status :: T.Text }
   deriving ( Eq, Show, Ord, Generic
            , ToSchema   HealthCheckSchema "ServerStatus"
-           , FromSchema HealthCheckSchema "ServerStatus" )
+           , FromSchema HealthCheckSchema "ServerStatus"
+           , Swagger.ToSchema )
   deriving (J.ToJSON, J.FromJSON)
     via (WithSchema HealthCheckSchema "ServerStatus" ServerStatusMsg)
 data HealthStatusMsg
   = HealthStatusMsg { hc :: Maybe HealthCheckMsg, status :: Maybe ServerStatusMsg }
   deriving ( Eq, Show, Ord, Generic
            , ToSchema   HealthCheckSchema "HealthStatus"
-           , FromSchema HealthCheckSchema "HealthStatus" )
+           , FromSchema HealthCheckSchema "HealthStatus"
+           , Swagger.ToSchema )
   deriving (J.ToJSON, J.FromJSON)
     via (WithSchema HealthCheckSchema "HealthStatus" HealthStatusMsg)
 newtype AllStatusMsg
   = AllStatusMsg { all :: [HealthStatusMsg] }
   deriving ( Eq, Show, Ord, Generic
            , ToSchema   HealthCheckSchema "AllStatus"
-           , FromSchema HealthCheckSchema "AllStatus" )
+           , FromSchema HealthCheckSchema "AllStatus"
+           , Swagger.ToSchema )
   deriving (J.ToJSON, J.FromJSON)
     via (WithSchema HealthCheckSchema "AllStatus" AllStatusMsg)

--- a/examples/health-check/src/Server.hs
+++ b/examples/health-check/src/Server.hs
@@ -154,7 +154,7 @@ instance MonadMonitor m => MonadMonitor (TraceT m)
 -- Information for servant
 
 type instance AnnotatedPackage ServantRoute HealthCheckServiceFS2
-  = '[ 'AnnPackage ('ServantAdditional ('Just (SwaggerSchemaUI "swagger-ui" "swagger.json")))
+  = '[ 'AnnPackage ('ServantAdditional (SwaggerSchemaUI "swagger-ui" "swagger.json"))
      , 'AnnService "HealthCheckServiceFS2"
                    ('ServantTopLevelRoute '["health"])
      , 'AnnMethod "HealthCheckServiceFS2" "setStatus"

--- a/generate-haddock-docs.sh
+++ b/generate-haddock-docs.sh
@@ -15,9 +15,10 @@ stack exec --no-ghc-package-path standalone-haddock -- -o ${DOCSDIR} \
   --package-db=$(stack path --snapshot-pkg-db) \
   --package-db=$(stack path --local-pkg-db) \
   --hyperlink-source \
-  core/schema core/rpc core/optics \
+  core/schema core/rpc core/optics core/lens \
   adapter/avro adapter/protobuf adapter/persistent adapter/kafka \
-  grpc/common grpc/client grpc/server graphql
+  instrumentation/prometheus instrumentation/tracing \
+  grpc/common grpc/client grpc/server graphql servant/server
 
 echo "Setting Linuwial theme on Haddock generated docs"
 if [ "$1" == "ocean" ]

--- a/servant/server/mu-servant-server.cabal
+++ b/servant/server/mu-servant-server.cabal
@@ -34,7 +34,9 @@ library
     , mu-schema
     , servant
     , servant-server
+    , servant-swagger
     , stm
+    , swagger2
     , utf8-string
 
   hs-source-dirs:   src

--- a/servant/server/src/Mu/Servant/Server.hs
+++ b/servant/server/src/Mu/Servant/Server.hs
@@ -13,151 +13,26 @@
 {-# language TypeOperators         #-}
 {-# language UndecidableInstances  #-}
 
--- |
--- = Transforming a Mu server into a Servant server
--- A Mu server is a collection of `Method` /handlers/. A "Servant" /also/ contains handlers, in a similar structure. This package contains a function `servantServerHandlers` which unpacks the Mu handlers and repackages them as "Servant" handlers, with some minor changes to support streaming, and a natural transformation allow the Mu handlers to operate in "Servant"'s natural `Handler` type. The trickier part, however, is translating the Mu server /type/ into a "Servant" server /type/. There are essentially four categories of `Method` types and each of these is translated slightly differently to a "Servant" API type.
---
--- == Translating methods
---
--- === Full Unary
---
--- Full unary methods have non-streaming arguments and a non-streaming response. Most HTTP endpoints expect unary requests and return unary responses. Unary method handlers look like this
---
--- > (MonadServer m) => requestType -> m responseType
---
--- For a handler like this, the corresponding "Servant" API type would be
---
--- @
--- type MyUnaryAPI =
---   route :>
---     `ReqBody` ctypes1 requestType :>
---       `Verb` method status ctypes2 responseType
--- @
---
--- As you can see, the request body contains a @requestType@ value, and the response body contains a @responseType@ value. @route@, @ctypes1@, @method@, @status@ and @ctypes2@ are derived from Mu annotations, which are covered in detail later on.
---
--- === Server Streaming
---
--- Server streaming methods have non-streaming arguments, but the response is streamed back to the client. Server stream handlers look like this
---
--- > (MonadServer m) => requestType -> `ConduitT` responseType `Void` m () -> m ()
---
--- For a handler like this, the corresponding "Servant" API type would be
---
--- @
--- type MyServerStreamAPI =
---   route :>
---     `ReqBody` ctypes requestType :>
---       `Stream` method status framing ctype (`SourceIO` (`StreamResult` responseType))
--- @
---
--- The request body contains a @requestType@ value. The response body is a stream of @`StreamResult` responseType@ values. @`StreamResult` responseType@ contains either a @responseType@ value or an error message describing a problem that occurred while producing @responseType@ values. @route@, @ctypes@, @method@, @status@, @framing@ and @ctype@ are derived from Mu annotations.
---
--- === Client Streaming
---
--- Client streaming methods have a streaming argument, but the response is unary. Client stream handlers look like this
---
--- > (MonadServer m) => `ConduitT` () requestType m () -> m responseType
---
--- For a handler like this, the corresponding "Servant" API type would be
---
--- @
--- type MyClientStreamAPI =
---   route :>
---     `StreamBody` framing ctype (`SourceIO` requestType) :>
---       `Verb` method status ctypes responseType
--- @
---
--- The response body contains a @responseType@ value. The request body is a stream of @requestType@ values. @route@, @ctypes@, @method@, @status@, @framing@, and @ctype@ are derived from Mu annotations.
---
--- === Bidirectional Streaming
---
--- Bidirectional streaming method have a streaming argument and a streaming response. Bidirectional stream handlers look like this
---
--- > (MonadServer m) => `ConduitT` () requestType m () -> `ConduitT` responseType Void m () -> m()
---
--- For a handler like this, the corresponding "Servant" API type would be
---
--- @
--- type MyBidirectionalStreamAPI =
---   `StreamBody` framing1 ctype1 (`SourceIO` requestType) :>
---     `Stream` method status framing2 ctype2 (`SourceIO` (`StreamResult` responseType))
--- @
---
--- This type should look familiar if you already looked at the server streaming and client streaming examples. The request body is a stream of @requestType@ values, and the response body is a stream of @`StreamResult` responseType@ values. All the other types involved are derived from Mu annotations, as described below.
---
--- == Required Type Family Instances
---
--- When Mu methods are converted to Servant APIs, you may customize certain aspects of the resulting API, including the route, HTTP method, and HTTP status.  Additionally, you must specify which content types use be used when encoding and decoding each type in your schema that appears in your methods. All of this customization is done with annotations, via the `AnnotatedSchema` and `AnnotatedPackage` type families.
---
--- The minimum `AnnotatedPackage` instances:
---
--- @
--- type instance `AnnotatedPackage` `ServantRoute` MyPackage = '[]
--- type instance `AnnotatedPackage` `ServantMethod` MyPackage = '[]
--- type instance `AnnotatedPackage` `ServantStatus` MyPackage = '[]
--- @
---
--- These instances have no annotations, so the default route, method, and status code
--- will be used for every RPC.
---
--- On the other hand, schema annotations are required for all the message types in
--- your RPCs - empty instances are not sufficient.
---
--- Let's look at an example RPC:
---
--- @
--- type MyMethod =
---   `Method` \"MyMethod\"
---     '[ '`ArgSingle` '`Nothing` ('`SchemaRef` MySchema \"InputMessage\") ]
---     ('`RetStream` ('`SchemaRef` MySchema \"OutputMessage\"))
--- @
---
--- This method takes an message of type @\"InputMessage\"@ from @MySchema@ as it's only argument. This will be translated to a `ReqBody` in the corresponding Servant API, but `ReqBody` requires a list of acceptable content types for the request. This list of content types must be specified for the @\"InputMessage\"@ type, like so
---
--- @
--- type instance `AnnotatedSchema` `ServantUnaryContentTypes` MySchema =
---   '[ '`AnnType` \"InputMessage\" ('`ServantUnaryContentTypes` '[`JSON`, `PlainText`])
---    ]
--- @
---
--- This instance says that whenever @\"InputMessage\"@ is used as a unary (non-streaming) request or repsonse body, that message can be encoded or decoded as JSON (application\/json) or plain text (text\/plain). The `MimeRender`\/`MimeUnrender` instances necessary to perform this encoding\/decoding must exist for the Haskell type you use to represent @\"InputMessage\"@ messages. For the RPC return type on the other hand, the type @\"OutputMessage\"@ from @MySchema@ is used in a stream, so another type instance must be made, like so
---
--- @
--- type instance `AnnotatedSchema` `ServantStreamContentType` MySchema =
---   '[ '`AnnType` \"OutputMessage\" ('`ServantStreamContentType` `NewlineFraming` `JSON`)
---    ]
--- @
--- This instance says that whenever the @\"OutputMessage\"@ schema type is used in a request stream or response stream it should be encoded\/decoded using newline-delimited JSON. This requires `MimeRender`\/`MimeUnrender` instances to exist, just like the unary case.
---
--- If you forget to provide one of these required instances, you will see a message like the following:
---
--- @
---     • Missing required AnnotatedPackage ServantRoute type instance
---       for \"myschema\" package
---     • When checking the inferred type
--- @
---
--- followed by a large and difficult to read type representing several stuck type families.  This message is an indication that you must provide an `AnnotatedPackage` type instance, with a domain of `ServantRoute` for the package with the name @myschema@. Thus, the following code should fix the error:
---
--- @
--- type instance `AnnotatedPackage` `ServantRoute` MySchema = '[]
--- @
---
--- Please see the executable in this package for a full working example server, including the necessary type instances.
+{-|
+Description : Execute a Mu 'Server' using Servant
 
+This module allows you to serve a Mu 'Server'
+as an OpenAPI / Swagger / REST end-point.
+In particular, it translates to the kind of
+type-level APIs used by Servant.
+-}
 module Mu.Servant.Server (
+  -- * Convert Mu to Servant
   servantServerHandlers,
   servantServerHandlersExtra,
+  toHandler,
   packageAPI,
   swagger,
+  -- * Required annotations
   ServantRoute(..),
   DefaultServantContentTypes,
   ServantContentTypes(..),
   ServantStreamContentType(..),
-  StreamResult(..),
-  toHandler,
-  convertServerError,
   -- Reexports
   StdMethod(..),
   module Servant.API
@@ -186,11 +61,11 @@ import           Servant.API
 import           Servant.Swagger
 import           Servant.Types.SourceT
 
--- | reinterprets a Mu server action as a "Servant" server action by converting Mu `Mu.Server.ServerError`s into Servant `Servant.ServerError`s via `convertServerError``
+-- | Reinterprets a Mu server action as a Servant handler.
 toHandler :: ServerErrorIO a -> Handler a
 toHandler = Handler . withExceptT convertServerError
 
--- | translates a Mu `Mu.Server.ServerError` into a "Servant" `Servant.ServerError`
+-- | Translates a Mu `Mu.Server.ServerError` into a Servant `Servant.ServerError`.
 convertServerError :: Mu.Server.ServerError -> Servant.ServerError
 convertServerError (Mu.Server.ServerError code msg) = case code of
   Unknown         -> err502 {errBody = LB8.fromString msg}
@@ -201,7 +76,10 @@ convertServerError (Mu.Server.ServerError code msg) = case code of
   Invalid         -> err400 {errBody = LB8.fromString msg}
   NotFound        -> err404 {errBody = LB8.fromString msg}
 
--- | converts a Mu server into "Servant" server by running all Mu handler actions in the `Handler` type
+-- | Converts a Mu server into Servant server
+--   by running all Mu handler actions in the `Handler` type.
+--   This version assumes /no/ additional routes
+--   in the Servant server when compared to Mu's.
 servantServerHandlers ::
   forall pname m chn ss handlers.
   ( ServantServiceHandlers
@@ -211,13 +89,17 @@ servantServerHandlers ::
       ss
       handlers
   , ExtraFor ('Package pname ss) ~ EmptyAPI
-  ) =>
-  (forall a. m a -> Handler a) ->
-  Mu.Server.ServerT chn () ('Package pname ss) m handlers ->
-  Servant.Server (PackageAPI ('Package pname ss) handlers)
+  )
+  => (forall a. m a -> Handler a) -- ^ how to turn the inner Mu monad into 'Handler', use 'toHandler' (or a composition with it) in most cases
+  -> Mu.Server.ServerT chn () ('Package pname ss) m handlers  -- ^ server to be converted
+  -> Servant.Server (PackageAPI ('Package pname ss) handlers)
 servantServerHandlers f (Services svcs) =
   emptyServer :<|> servantServiceHandlers f (Proxy @('Package pname ss)) svcs
 
+-- | Converts a Mu server into Servant server
+--   by running all Mu handler actions in the `Handler` type.
+--   This version should be used when additional
+--   routes have been added in the Servant version.
 servantServerHandlersExtra ::
   forall pname m chn ss handlers.
   ( ServantServiceHandlers
@@ -226,21 +108,24 @@ servantServerHandlersExtra ::
       chn
       ss
       handlers
-  ) =>
-  (forall a. m a -> Handler a) ->
-  Server (ExtraFor ('Package pname ss)) ->
-  Mu.Server.ServerT chn () ('Package pname ss) m handlers ->
-  Servant.Server (PackageAPI ('Package pname ss) handlers)
+  )
+  => (forall a. m a -> Handler a) -- ^ how to turn the inner Mu monad into 'Handler', use 'toHandler' (or a composition with it) in most cases
+  -> Server (ExtraFor ('Package pname ss)) -- ^ additional handler for the extra route
+  -> Mu.Server.ServerT chn () ('Package pname ss) m handlers  -- ^ server to be converted
+  -> Servant.Server (PackageAPI ('Package pname ss) handlers)
 servantServerHandlersExtra f extra (Services svcs) =
   extra :<|> servantServiceHandlers f (Proxy @('Package pname ss)) svcs
 
+-- | Converts the information from a Mu server
+--   into a 'Swagger' document.
 swagger :: forall pname ss handlers chn m.
            HasSwagger (ServicesAPI ('Package pname ss) ss handlers)
         => Mu.Server.ServerT chn () ('Package pname ss) m handlers
         -> Swagger
 swagger _ = toSwagger (Proxy @(ServicesAPI ('Package pname ss) ss handlers))
 
--- | used to obtain a "Servant" API proxy value for use with functions like `layout` that expect such values as arguments
+-- | Obtains a Servant API 'Proxy' value for use
+--   with functions like 'serve' and 'layout'.
 packageAPI :: Mu.Server.ServerT chn t pkg s handlers -> Proxy (PackageAPI pkg handlers)
 packageAPI _ = Proxy
 


### PR DESCRIPTION
It turns out that turning @andremarianiello's work into a full OpenAPI server was quite easy, thanks to `servant-swagger`. This adds the necessary boilerplate in `mu-servant-server`, and also shows how to use `servant-swaggerui` to expose the nice UI from Swagger.