### PR TITLE
Improve the Library example (with persistent)

### DIFF
--- a/examples/library/library.graphql
+++ b/examples/library/library.graphql
@@ -14,6 +14,11 @@ input NewAuthor {
   name: String!
 }
 
+input NewBook {
+  title: String!
+  authorId: Int!
+}
+
 type Query {
   authors(name: String! = "%"): [Author!]!
   books(title: String! = "%"): [Book!]!
@@ -21,6 +26,7 @@ type Query {
 
 type Mutation {
   newAuthor(author: NewAuthor!): Author
+  newBook(book: NewBook!): Book
 }
 
 type Subscription {

--- a/examples/library/src/Schema.hs
+++ b/examples/library/src/Schema.hs
@@ -44,9 +44,19 @@ Author json
 Book json
   title T.Text
   author AuthorId
+  UniqueTitlePerAuthor title author
   deriving Show Generic
 |]
+
+toAuthorId :: Int64 -> AuthorId
+toAuthorId = toSqlKey
 
 newtype NewAuthor = NewAuthor { name :: T.Text }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (FromSchema LibrarySchema "NewAuthor")
+
+data NewBook
+  = NewBook { title    :: T.Text
+            , authorId :: Integer }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromSchema LibrarySchema "NewBook")

--- a/examples/library/src/Server.hs
+++ b/examples/library/src/Server.hs
@@ -10,6 +10,7 @@
 
 module Main where
 
+import           Control.Monad.Except              (catchError)
 import           Control.Monad.IO.Class            (liftIO)
 import           Control.Monad.Logger
 import           Data.Conduit
@@ -30,7 +31,6 @@ import           Schema
 
 main :: IO ()
 main = do
-  putStrLn "starting GraphQL server on port 8000"
   -- Setup CORS
   let hm = addHeaders [
              ("Access-Control-Allow-Origin", "*")
@@ -39,14 +39,40 @@ main = do
   -- Set up Prometheus
   p <- initPrometheus "library"
   -- Run the whole thing
-  runStderrLoggingT $
+  runStdoutLoggingT $
     withSqliteConn @(LoggingT IO) ":memory:" $ \conn -> do
       runDb conn $ runMigration migrateAll
+      -- Insert demo data
+      insertSeedData conn
+      liftIO $ putStrLn "starting GraphQL server on port 8000"
       liftIO $ run 8000 $ hm $
         graphQLApp (prometheus p $ libraryServer conn)
                    (Proxy @('Just "Query"))
                    (Proxy @('Just "Mutation"))
                    (Proxy @('Just "Subscription"))
+
+{- | Inserts demo data to make this example valueable for testing with different clients
+Returns Nothing in case of any failure, including attempts to insert non-unique values
+-}
+insertSeedData :: SqlBackend -> LoggingT IO (Maybe ())
+insertSeedData conn = sequence_ <$> sequence
+  [ insertAuthorAndBooks conn (Author "Robert Louis Stevenson")
+      [Book "Treasure Island", Book "Strange Case of Dr Jekyll and Mr Hyde"]
+  , insertAuthorAndBooks conn (Author "Immanuel Kant")
+      [Book "Critique of Pure Reason"]
+  , insertAuthorAndBooks conn (Author "Michael Ende")
+      [Book "The Neverending Story", Book "Momo"]
+  ]
+
+{- | Inserts Author and Books
+Returns Nothing in case of any failure, including attempts to insert non-unique values
+-}
+insertAuthorAndBooks :: SqlBackend -> Author -> [Key Author -> Book] -> LoggingT IO (Maybe ())
+insertAuthorAndBooks conn author books =
+  (`catchError` (const $ return Nothing)) . runDb conn . fmap sequence_ $
+    do
+      Just authorId <- insertUnique author
+      mapM (insertUnique . ($ authorId)) books
 
 
 type ObjectMapping = '[
@@ -58,15 +84,16 @@ libraryServer :: forall i.
                  SqlBackend
               -> ServerT ObjectMapping i Library ServerErrorIO _
 libraryServer conn
-  = resolver ( object @"Book"     ( field  @"id"       bookId
-                                  , field  @"title"    bookTitle
-                                  , field  @"author"   bookAuthor )
-             , object @"Author"   ( field  @"id"       authorId
-                                  , field  @"name"     authorName
-                                  , field  @"books"    authorBooks )
-             , object @"Query"    ( method @"authors"  allAuthors
-                                  , method @"books"    allBooks )
-             , object @"Mutation" (method @"newAuthor" newAuthor)
+  = resolver ( object @"Book"     ( field  @"id"        bookId
+                                  , field  @"title"     bookTitle
+                                  , field  @"author"    bookAuthor )
+             , object @"Author"   ( field  @"id"        authorId
+                                  , field  @"name"      authorName
+                                  , field  @"books"     authorBooks )
+             , object @"Query"    ( method @"authors"   allAuthors
+                                  , method @"books"     allBooks )
+             , object @"Mutation" ( method @"newAuthor" newAuthor
+                                  , method @"newBook"   newBook )
              , object @"Subscription" ( method @"allBooks" allBooksConduit )
              )
   where
@@ -101,5 +128,11 @@ libraryServer conn
     newAuthor :: NewAuthor -> ServerErrorIO (Maybe (Entity Author))
     newAuthor (NewAuthor name) = runDb conn $ do
       let new = Author name
+      result <- insertUnique new
+      pure $ Entity <$> result <*> pure new
+
+    newBook :: NewBook -> ServerErrorIO (Maybe (Entity Book))
+    newBook (NewBook title authorId) = runDb conn $ do
+      let new = Book title (toAuthorId $ fromInteger authorId)
       result <- insertUnique new
       pure $ Entity <$> result <*> pure new

--- a/examples/library/src/Server.hs
+++ b/examples/library/src/Server.hs
@@ -69,10 +69,9 @@ Returns Nothing in case of any failure, including attempts to insert non-unique 
 -}
 insertAuthorAndBooks :: SqlBackend -> Author -> [Key Author -> Book] -> LoggingT IO (Maybe ())
 insertAuthorAndBooks conn author books =
-  (`catchError` (const $ return Nothing)) . runDb conn . fmap sequence_ $
-    do
-      Just authorId <- insertUnique author
-      mapM (insertUnique . ($ authorId)) books
+  (`catchError` (const $ return Nothing)) . runDb conn . fmap sequence_ $ do
+    Just authorId <- insertUnique author
+    mapM (insertUnique . ($ authorId)) books
 
 
 type ObjectMapping = '[

--- a/examples/library/src/Server.hs
+++ b/examples/library/src/Server.hs
@@ -71,7 +71,7 @@ insertAuthorAndBooks :: SqlBackend -> Author -> [Key Author -> Book] -> LoggingT
 insertAuthorAndBooks conn author books =
   (`catchError` (const $ pure Nothing)) . runDb conn . fmap sequence_ $ do
     Just authorId <- insertUnique author
-    mapM (insertUnique . ($ authorId)) books
+    traverse (insertUnique . ($ authorId)) books
 
 
 type ObjectMapping = '[

--- a/examples/library/src/Server.hs
+++ b/examples/library/src/Server.hs
@@ -69,7 +69,7 @@ Returns Nothing in case of any failure, including attempts to insert non-unique 
 -}
 insertAuthorAndBooks :: SqlBackend -> Author -> [Key Author -> Book] -> LoggingT IO (Maybe ())
 insertAuthorAndBooks conn author books =
-  (`catchError` (const $ return Nothing)) . runDb conn . fmap sequence_ $ do
+  (`catchError` (const $ pure Nothing)) . runDb conn . fmap sequence_ $ do
     Just authorId <- insertUnique author
     mapM (insertUnique . ($ authorId)) books
 

--- a/examples/library/src/Server.hs
+++ b/examples/library/src/Server.hs
@@ -39,7 +39,7 @@ main = do
   -- Set up Prometheus
   p <- initPrometheus "library"
   -- Run the whole thing
-  runStdoutLoggingT $
+  runStderrLoggingT $
     withSqliteConn @(LoggingT IO) ":memory:" $ \conn -> do
       runDb conn $ runMigration migrateAll
       -- Insert demo data

--- a/examples/library/src/Server.hs
+++ b/examples/library/src/Server.hs
@@ -67,10 +67,9 @@ Returns Nothing in case of any failure, including attempts to insert non-unique 
 -}
 insertAuthorAndBooks :: SqlBackend -> Author -> [Key Author -> Book] -> LoggingT IO (Maybe ())
 insertAuthorAndBooks conn author books =
-  runDb conn $ do
+  runDb conn $ (>>= sequence_) <$> do
     authorResult <- insertUnique author
-    maybeBooks <- traverse (\authorId -> traverse (insertUnique . ($ authorId)) books) authorResult
-    pure $ maybeBooks >>= sequence_
+    traverse (\authorId -> traverse (insertUnique . ($ authorId)) books) authorResult
 
 type ObjectMapping = '[
     "Book"   ':-> Entity Book


### PR DESCRIPTION
Hi!

My goal is to have a comprehensive example to use with different clients (such as with `elm-graphql` and other languages). So I changed this:

- Add `newBook` mutation
- Insert demo data to be instantly available when server starts (same demo data as in `library-graphql` executable) 
- Add uniqueness constraint for a tuple of a book title and book author id