### PR TITLE
library example: Use serverError instead of optional results

### DIFF
--- a/examples/library/library.graphql
+++ b/examples/library/library.graphql
@@ -25,8 +25,8 @@ type Query {
 }
 
 type Mutation {
-  newAuthor(author: NewAuthor!): Author
-  newBook(book: NewBook!): Book
+  newAuthor(author: NewAuthor!): Author!
+  newBook(book: NewBook!): Book!
 }
 
 type Subscription {


### PR DESCRIPTION
Hi!

I consider (using mandatory results for mutations + providing error messages) to be a better practice than returning nullable results because it explains the reason for failure.
Also, It's a bit easier to implement clients when results are required because in the case of `Nothing` the `newBook` or `newAuthor` field completely disappears from the JSON `data` object (though I understand that this case is both an encoding nuance and a decoding issue).