### PR TITLE
Issue: example error parsing problem

### DIFF
--- a/examples/error-parsing/LICENSE
+++ b/examples/error-parsing/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright © 2019-2020 47 Degrees. <http://47deg.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/error-parsing/errorparsing.proto
+++ b/examples/error-parsing/errorparsing.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package hello;
+
+message HelloRequest { string name = 1; }
+message HelloReply { string reply = 1; }
+
+service Service {
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}

--- a/examples/error-parsing/hie.yaml
+++ b/examples/error-parsing/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { stack: { component: "mu-example-error-parsing:exe:error-parsing-server" } }

--- a/examples/error-parsing/mu-example-error-parsing.cabal
+++ b/examples/error-parsing/mu-example-error-parsing.cabal
@@ -1,0 +1,43 @@
+name:          mu-example-error-parsing
+version:       0.4.0.0
+synopsis:
+  Example error-parsing project
+
+description:
+  Example error-parsing project
+
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Alejandro Serrano
+maintainer:    alejandro.serrano@47deg.com
+copyright:     Copyright © 2019-2020 47 Degrees. <http://47deg.com>
+cabal-version: >=1.10
+category:      Network
+build-type:    Simple
+data-files:    errorparsing.proto
+bug-reports:   https://github.com/higherkindness/mu-haskell/issues
+
+executable error-parsing
+  main-is:          Main.hs
+  other-modules:    ProtoExample
+  build-depends:
+      AC-Angle        >=1     && <2
+    , async           >=2.2   && <3
+    , base            >=4.12  && <5
+    , conduit         >=1.3.2 && <2
+    , hashable        >=1.3   && <2
+    , mu-grpc-server  >=0.4.0
+    , mu-grpc-client  >=0.4.0
+    , mu-protobuf     >=0.4.0
+    , mu-rpc          >=0.4.0
+    , mu-schema       >=0.3.0
+    , http2-client    >=0.8
+    , stm             >=2.5   && <3
+    , stm-chans       >=3     && <4
+    , text            >=1.2   && <2
+    , time            >=1.9   && <2
+    , transformers    >=0.5   && <0.6
+
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  ghc-options:      -Wall

--- a/examples/error-parsing/src/Main.hs
+++ b/examples/error-parsing/src/Main.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+
+module Main where
+
+import Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import Data.Either
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.IO (finally)
+import Mu.GRpc.Client.Record
+import Mu.GRpc.Client.TyApps
+import Mu.GRpc.Server
+import Mu.Server hiding (resolver)
+import Network.HTTP2.Client
+import ProtoExample
+import Prelude
+
+------------------------------------------------------------------------------
+-- app
+
+runServer :: IO ()
+runServer = do
+  runGRpcApp msgProtoBuf 8070 grpcServer
+
+------------------------------------------------------------------------------
+-- grpc server api
+
+grpcServer :: MonadServer m => SingleServerT i Service m _
+grpcServer =
+  singleService
+    ( method @"SayHello" sayHello
+    )
+
+sayHello :: MonadServer m => HelloRequestMessage -> m HelloReplyMessage
+sayHello (HelloRequestMessage nm) = do
+  case nm of
+    -- in some cases we want to throw an error, here when the name sent is 'Bob'
+    "Bob" -> throwError $ ServerError NotFound "Bob not there"
+    _ -> pure $ HelloReplyMessage ("hi, " <> nm)
+
+------------------------------------------------------------------------------
+-- grpc client calls
+
+outboundSayHello' :: HostName -> PortNumber -> T.Text -> IO (GRpcReply Text)
+outboundSayHello' host port req = do
+  attempt <- setupGrpcClient' (grpcClientConfigSimple host port False)
+  case attempt of
+    Right c -> do
+      x <- fmap (\(HelloReplyMessage r) -> r) <$> outBoundSayHello c (HelloRequestMessage req)
+      pure x
+    _ -> undefined
+
+outBoundSayHello :: GrpcClient -> HelloRequestMessage -> IO (GRpcReply HelloReplyMessage)
+outBoundSayHello = gRpcCall @'MsgProtoBuf @Service @"Service" @"SayHello"
+
+------------------------------------------------------------------------------
+-- test
+
+runTest :: IO ()
+runTest = do
+  putStrLn "testing things..."
+  aliceResult <- outboundSayHello' "127.0.0.1" 8070 "Alice"
+  putStr "The result for saying hello to Alice: "
+  print (show aliceResult)
+  bobResult <- outboundSayHello' "127.0.0.1" 8070 "Bob"
+  -- bobResult should give a valid error from the server (NotFound), instead of a generic "not enough bytes"
+  putStr "The result for saying hello to Bob: "
+  print bobResult
+  putStrLn "done with the haskell test, waiting 10 seconds before shutting down..."
+  threadDelay $ 10 * 1000000 -- wait 10 seconds to allow running grpcurl against the server, too.
+
+main :: IO ()
+main = do
+  server <- Async.async runServer
+  finally runTest (Async.cancel server)

--- a/examples/error-parsing/src/ProtoExample.hs
+++ b/examples/error-parsing/src/ProtoExample.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module ProtoExample where
+
+import Data.Text as T
+import GHC.Generics
+import Mu.Quasi.GRpc
+import Mu.Schema
+
+grpc "TheSchema" id "errorparsing.proto"
+
+data HelloRequestMessage = HelloRequestMessage {name :: T.Text}
+  deriving
+    ( Eq,
+      Show,
+      Generic,
+      ToSchema TheSchema "HelloRequest",
+      FromSchema TheSchema "HelloRequest"
+    )
+
+data HelloReplyMessage = HelloReplyMessage {reply :: T.Text}
+  deriving
+    ( Eq,
+      Show,
+      Generic,
+      ToSchema TheSchema "HelloReply",
+      FromSchema TheSchema "HelloReply"
+    )

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,7 @@ packages:
 - examples/route-guide
 - examples/seed
 - examples/todolist
+- examples/error-parsing
 - examples/with-persistent
 - graphql
 - grpc/client


### PR DESCRIPTION
This PR is twofold:

1. bug report
2. question about unit testing

## 1. bug report

As we deviate from the "happy path" (e.g. here when throwing an error), using mu-grpc-client becomes problematic.

To run this example:

```
stack exec error-parsing
```

Output:
```
testing things...
The result for saying hello to Alice: "GRpcOk \"hi, Alice\""
The result for saying hello to Bob: GRpcErrorString "not enough bytes"
done with the haskell test, waiting 10 seconds before shutting down...
```

As can be seen, any error thrown will be falsely interpreted by grpc-client as
"GRpcErrorString". This makes any real-life application with grpcclient
impossible (there are not just happy paths, and not all errors are the
same)

The server side implementation appears correct, as I can poke the server
with the grpcurl tool:

```
grpcurl -d '{"name": "Bobby"}' -format json -plaintext -proto errorparsing.proto localhost:8070 hello.Service.SayHello
{
  "reply": "hi, Bobby"
}

grpcurl -d '{"name": "Bob"}' -format json -plaintext -proto errorparsing.proto localhost:8070 hello.Service.SayHello
ERROR:
  Code: NotFound
  Message: Bob not there
```

Related issue: https://github.com/haskell-grpc-native/http2-grpc-haskell/issues/6

## Why am I filing this PR here?

Providing easy-to run example code along a github issue is hard, therefore I opted to use a PR instead.

More generally, I would have preferred to make this example a unit test (expecting the reply from Bob to be of a certain type which is not `GRpcErrorString "not enough bytes"`), however this whole project seems to not contain any unit tests at all.

## Question about unit tests and production-readyness

Do you plan to set up some tasty or hspec (or something else) unit tests more generally? (why are there no unit tests so far? That makes me doubt whether the mu family of libraries can safely be used in any project other than toy projects. Can you comment on the stability of the libraries outside this particular bug?) 

In case unit tests are more generally set up, this PR could be converted to be another unit test, which would allow to more easily catch other parsing issues in the mu family of libraries.